### PR TITLE
Refine plugin navigation with user-friendly names and descriptions

### DIFF
--- a/plugin_base.py
+++ b/plugin_base.py
@@ -1,8 +1,10 @@
 class ToolPlugin:
     name = ""
+    plugin_name = ""
     usage = ""
     platforms = []
     notifier = False
+    plugin_dec = ""
     settings_category = None
     required_settings = {}
 

--- a/plugins/automatic_plugin.py
+++ b/plugins/automatic_plugin.py
@@ -16,6 +16,7 @@ load_dotenv()
 
 class AutomaticPlugin(ToolPlugin):
     name = "automatic_plugin"
+    plugin_name = "Automatic1111 Image"
     usage = (
         "{\n"
         '  "function": "automatic_plugin",\n'
@@ -23,6 +24,7 @@ class AutomaticPlugin(ToolPlugin):
         "}\n"
     )
     description = "Draws a picture using a prompt provided by the user using AUTOMATIC1111 API."
+    plugin_dec = "Generate an image from a text prompt using your Automatic1111 server."
     settings_category = "Automatic111"
     pretty_name = "Your Image"
     required_settings = {

--- a/plugins/broadcast.py
+++ b/plugins/broadcast.py
@@ -19,6 +19,7 @@ class BroadcastPlugin(ToolPlugin):
     Mimics the doorbell_alert TTS behavior (tts/speak with fallback to tts/piper_say).
     """
     name = "broadcast"
+    plugin_name = "Broadcast"
     usage = (
         "{\n"
         '  "function": "broadcast",\n'
@@ -32,6 +33,7 @@ class BroadcastPlugin(ToolPlugin):
         "Use ONLY when the user explicitly asks to broadcast/announce/page an audio message (e.g., 'announce dinner is ready', "
         "'broadcast this', 'page the house') and provides what to say."
     )
+    plugin_dec = "Send a one-time spoken announcement to your Home Assistant media players."
     pretty_name = "Broadcast Announcement"
     settings_category = "Broadcast"
 

--- a/plugins/camera_event.py
+++ b/plugins/camera_event.py
@@ -29,7 +29,9 @@ class CameraEventPlugin(ToolPlugin):
     Stores events per-area (e.g., 'front_yard', 'back_yard') and stamps with HA local-naive ISO time.
     """
     name = "camera_event"
+    plugin_name = "Camera Event"
     description = "Camera event tool for when the user requests or says to run camera event."
+    plugin_dec = "Capture a Home Assistant camera snapshot, describe it with vision AI, and log the event."
     usage = (
         "{\n"
         '  "function": "camera_event",\n'

--- a/plugins/comfyui_audio_ace.py
+++ b/plugins/comfyui_audio_ace.py
@@ -19,6 +19,7 @@ logger.setLevel(logging.INFO)
 
 class ComfyUIAudioAcePlugin(ToolPlugin):
     name = "comfyui_audio_ace"
+    plugin_name = "ComfyUI Audio Ace"
     usage = (
         '{\n'
         '  "function": "comfyui_audio_ace",\n'
@@ -26,6 +27,7 @@ class ComfyUIAudioAcePlugin(ToolPlugin):
         '}\n'
     )
     description = "Generates music using ComfyUI Audio Ace."
+    plugin_dec = "Compose a music track from a prompt with ComfyUI Audio Ace."
     pretty_name = "Your Song"
     settings_category = "ComfyUI Audio Ace"
     # ✅ Add Matrix support

--- a/plugins/comfyui_image_plugin.py
+++ b/plugins/comfyui_image_plugin.py
@@ -16,6 +16,7 @@ from helpers import redis_client, run_comfy_prompt
 
 class ComfyUIImagePlugin(ToolPlugin):
     name = "comfyui_image_plugin"
+    plugin_name = "ComfyUI Image"
     usage = (
         "{\n"
         '  "function": "comfyui_image_plugin",\n'
@@ -28,6 +29,7 @@ class ComfyUIImagePlugin(ToolPlugin):
         "}\n"
     )
     description = "Draws a picture using a prompt provided by the user using ComfyUI."
+    plugin_dec = "Generate a still image from a text prompt using your ComfyUI workflow."
     pretty_name = "Your Image"
     settings_category = "ComfyUI Image"
     required_settings = {

--- a/plugins/comfyui_image_video_plugin.py
+++ b/plugins/comfyui_image_video_plugin.py
@@ -14,6 +14,7 @@ from helpers import redis_client, get_latest_image_from_history, run_comfy_promp
 
 class ComfyUIImageVideoPlugin(ToolPlugin):
     name = "comfyui_image_video"
+    plugin_name = "ComfyUI Animate Image"
     usage = (
         '{\n'
         '  "function": "comfyui_image_video",\n'
@@ -21,6 +22,7 @@ class ComfyUIImageVideoPlugin(ToolPlugin):
         '}'
     )
     description = "Animates the most recent image in chat into a looping WebP or MP4 using ComfyUI."
+    plugin_dec = "Animate the most recent image in chat into a looping WebP or MP4 via ComfyUI."
     pretty_name = "Animating Your Image"
     settings_category = "ComfyUI Animate Image"
     required_settings = {

--- a/plugins/comfyui_music_video.py
+++ b/plugins/comfyui_music_video.py
@@ -16,6 +16,7 @@ from plugins.vision_describer import VisionDescriberPlugin
 
 class ComfyUIMusicVideoPlugin(ToolPlugin):
     name = "comfyui_music_video"
+    plugin_name = "ComfyUI Music Video"
     usage = (
         '{\n'
         '  "function": "comfyui_music_video",\n'
@@ -23,6 +24,7 @@ class ComfyUIMusicVideoPlugin(ToolPlugin):
         '}\n'
     )
     description = "Generates a complete AI music video including lyrics, music, and animated visuals by orchestrating ComfyUI plugins."
+    plugin_dec = "Build a full AI music video\u2014lyrics, music, and animated visuals\u2014using ComfyUI."
     pretty_name = "Your Music Video"
     platforms = ["webui"]
     waiting_prompt_template = "Generate a fun, upbeat message saying you're composing the full music video now! Only output that message."

--- a/plugins/comfyui_video_plugin.py
+++ b/plugins/comfyui_video_plugin.py
@@ -15,6 +15,7 @@ from plugins.comfyui_image_video_plugin import ComfyUIImageVideoPlugin
 
 class ComfyUIVideoPlugin(ToolPlugin):
     name = "comfyui_video_plugin"
+    plugin_name = "ComfyUI Video"
     usage = (
         '{\n'
         '  "function": "comfyui_video_plugin",\n'
@@ -22,6 +23,7 @@ class ComfyUIVideoPlugin(ToolPlugin):
         '}\n'
     )
     description = "Generates a video from a text prompt by creating multiple animated clips using ComfyUI, then merging them into one MP4."
+    plugin_dec = "Create a short video from a text prompt by stitching ComfyUI-generated clips."
     pretty_name = "Your Video"
     platforms = ["webui"]
     settings_category = "ComfyUI Video"

--- a/plugins/device_compare.py
+++ b/plugins/device_compare.py
@@ -21,6 +21,7 @@ logger.setLevel(logging.INFO)
 
 class DeviceComparePlugin(ToolPlugin):
     name = "device_compare"
+    plugin_name = "Device Compare"
     usage = (
         "{\n"
         '  "function": "device_compare",\n'
@@ -28,6 +29,7 @@ class DeviceComparePlugin(ToolPlugin):
         "}\n"
     )
     description = "Compares two devices by fetching specs and per-game FPS from multiple sources, then renders image tables."
+    plugin_dec = "Compare two devices with spec tables and per-game FPS benchmarks."
     pretty_name = "Comparing Devices"
     settings_category = "Device Compare"
     # Matrix supported (images only). IRC still not supported (images).

--- a/plugins/discord_notifier.py
+++ b/plugins/discord_notifier.py
@@ -11,7 +11,9 @@ logger = logging.getLogger("discord_notifier")
 
 class DiscordNotifierPlugin(ToolPlugin):
     name = "discord_notifier"
+    plugin_name = "Discord Notifier"
     description = "Posts RSS summaries to a Discord channel via webhook."
+    plugin_dec = "Post RSS summaries to a Discord channel via webhook."
     usage = ""
     platforms = []
     settings_category = "Discord Notifier"

--- a/plugins/doorbell_alert.py
+++ b/plugins/doorbell_alert.py
@@ -30,7 +30,9 @@ class DoorbellAlertPlugin(ToolPlugin):
     - ha_time is strict naive ISO 'YYYY-MM-DDTHH:MM:SS' (no timezone).
     """
     name = "doorbell_alert"
+    plugin_name = "Doorbell Alert"
     description = "Doorbell alert tool for when the user requests or says to run a doorbell alert."
+    plugin_dec = "Handle doorbell events: snapshot, describe with vision, announce, and log notifications."
     usage = (
         "{\n"
         '  "function": "doorbell_alert",\n'

--- a/plugins/emoji_ai_responder.py
+++ b/plugins/emoji_ai_responder.py
@@ -18,7 +18,9 @@ logger = logging.getLogger("emoji_ai_responder")
 
 class EmojiAIResponderPlugin(ToolPlugin):
     name = "emoji_ai_responder"
+    plugin_name = "Emoji AI Responder"
     description = "Uses LLM to pick an appropriate emoji when a user reacts to a message."
+    plugin_dec = "Pick an emoji reaction that matches a user's message."
     platforms = ["passive"]
 
     async def on_reaction_add(self, reaction, user):

--- a/plugins/events_query.py
+++ b/plugins/events_query.py
@@ -31,6 +31,7 @@ class EventsQueryPlugin(ToolPlugin):
       - "anything happen around the house today?"
     """
     name = "events_query"
+    plugin_name = "Events Query"
     pretty_name = "Events Query"
     description = (
         "Answer questions about stored household events (all sources) by area and timeframe. "
@@ -38,6 +39,7 @@ class EventsQueryPlugin(ToolPlugin):
         "or whether someone is currently there. The model should always include the original user question "
         "as the 'query' argument so context is preserved."
     )
+    plugin_dec = "Answer questions about stored household events by area and timeframe."
 
     usage = (
         "{\n"

--- a/plugins/events_query_brief.py
+++ b/plugins/events_query_brief.py
@@ -32,6 +32,7 @@ class EventsQueryBriefPlugin(ToolPlugin):
     """
 
     name = "events_query_brief"
+    plugin_name = "Events Query Brief"
     pretty_name = "Events Query (Brief)"
 
     description = (
@@ -39,6 +40,7 @@ class EventsQueryBriefPlugin(ToolPlugin):
         "(safe for dashboards). Can optionally write the summary into a Home Assistant "
         "input_text entity automatically."
     )
+    plugin_dec = "Produce a terse dashboard-friendly summary of recent home events and optionally write it to Home Assistant."
 
     # Cleaner: automation users usually just pick the tool name.
     # Args are optional overrides.

--- a/plugins/find_my_phone.py
+++ b/plugins/find_my_phone.py
@@ -27,6 +27,7 @@ class FindMyPhonePlugin(ToolPlugin):
     """
 
     name = "find_my_phone"
+    plugin_name = "Find My Phone"
     usage = (
         "{\n"
         '  "function": "find_my_phone",\n'
@@ -37,6 +38,7 @@ class FindMyPhonePlugin(ToolPlugin):
         "Use this when the user asks where their phone is, or asks to find, ring, "
         "locate, or make their phone play a sound."
     )
+    plugin_dec = "Ping or ring your phone through Home Assistant so you can locate it."
     pretty_name = "Finding Your Phone"
     settings_category = "Find My Phone"
     required_settings = {

--- a/plugins/ftp_browser.py
+++ b/plugins/ftp_browser.py
@@ -17,6 +17,7 @@ async def safe_send(channel, content: str, **kwargs):
 
 class FtpBrowserPlugin(ToolPlugin):
     name = "ftp_browser"
+    plugin_name = "FTP Browser"
     usage = (
         "{\n"
         '  "function": "ftp_browser",\n'
@@ -24,6 +25,7 @@ class FtpBrowserPlugin(ToolPlugin):
         "}\n"
     )
     description = "Lets the user browse and download files from the FTP server."
+    plugin_dec = "Browse and download files from the configured FTP server."
     pretty_name = "Connecting to FTP"
     settings_category = "FTPBrowser"
     required_settings = {

--- a/plugins/get_notifications.py
+++ b/plugins/get_notifications.py
@@ -11,6 +11,7 @@ logger.setLevel(logging.INFO)
 
 class GetNotificationsPlugin(ToolPlugin):
     name = "get_notifications"
+    plugin_name = "Get Notifications"
     usage = (
         "{\n"
         '  "function": "get_notifications",\n'
@@ -21,6 +22,7 @@ class GetNotificationsPlugin(ToolPlugin):
         "Fetches queued notifications from the Home Assistant bridge. "
         "Call this when the user asks for notifications or recent alerts."
     )
+    plugin_dec = "Fetch queued notifications from the Home Assistant bridge."
     pretty_name = "Get Notifications"
     settings_category = "Notifications"
     platforms = ["webui", "homeassistant"]

--- a/plugins/ha_control.py
+++ b/plugins/ha_control.py
@@ -57,6 +57,7 @@ class HAClient:
 
 class HAControlPlugin(ToolPlugin):
     name = "ha_control"
+    plugin_name = "Home Assistant Control"
     usage = (
         "{\n"
         '  "function": "ha_control",\n'
@@ -72,6 +73,7 @@ class HAControlPlugin(ToolPlugin):
         "}\n"
     )
     description = "Call this when the user wants to control or check a Home Assistant device, such as turning lights on or off, setting temperatures, or checking a sensor state."
+    plugin_dec = "Control or check Home Assistant devices like lights, thermostats, and sensors."
     pretty_name = "Home Assistant Control"
     settings_category = "Home Assistant"
     waiting_prompt_template = "Write a friendly message telling {mention} you’re controlling their Home Assistant devices now! Only output that message."

--- a/plugins/list_feeds.py
+++ b/plugins/list_feeds.py
@@ -16,6 +16,7 @@ redis_client = redis.Redis(host=redis_host, port=redis_port, db=0, decode_respon
 
 class ListFeedsPlugin(ToolPlugin):
     name = "list_feeds"
+    plugin_name = "List Feeds"
     usage = (
         "{\n"
         '  "function": "list_feeds",\n'
@@ -23,6 +24,7 @@ class ListFeedsPlugin(ToolPlugin):
         "}\n"
     )
     description = "Lists the RSS feeds currently being watched."
+    plugin_dec = "Show the RSS feeds currently being watched."
     pretty_name = "Getting RSS Feeds"
     waiting_prompt_template = (
         "Write a friendly, casual message telling {mention} you’re grabbing the current watched feeds now! Only output that message."

--- a/plugins/lowfi_video.py
+++ b/plugins/lowfi_video.py
@@ -19,6 +19,7 @@ CLIENT_ID = str(uuid.uuid4())
 
 class LowfiVideoPlugin(ToolPlugin):
     name = "lowfi_video"
+    plugin_name = "Lofi Video"
     usage = (
         "{\n"
         '  "function": "lowfi_video",\n'
@@ -28,6 +29,7 @@ class LowfiVideoPlugin(ToolPlugin):
         "}\n"
     )
     description = "Generates lofi audio via AceStep and loops a cozy animation to full length (MP4)."
+    plugin_dec = "Create a cozy lofi video by generating music and looping a matching animation."
     pretty_name = "Your Lofi Video"
     waiting_prompt_template = "Generate a fun, cozy message telling the user you're creating their lofi music video right now. Only output that message."
     settings_category = "Lofi Video"

--- a/plugins/mister_remote.py
+++ b/plugins/mister_remote.py
@@ -28,12 +28,14 @@ SYN = {
 
 class MisterRemotePlugin(ToolPlugin):
     name = "mister_remote"
+    plugin_name = "MiSTer Remote"
     pretty_name = "MiSTer Remote"
     description = (
         "Control MiSTer via the MiSTer Remote API.\n"
         "ALWAYS include the user's FULL original message in the `utterance` field when calling this tool.\n"
         "Examples users might say: 'play super mario 3 on mister', 'what’s playing?', 'go to menu', 'take a screenshot'."
     )
+    plugin_dec = "Control your MiSTer FPGA setup\u2014launch games, check status, or take screenshots."
 
     platforms = ["discord", "webui", "irc", "homeassistant", "matrix", "homekit"]
 

--- a/plugins/ntfy_notifier.py
+++ b/plugins/ntfy_notifier.py
@@ -12,7 +12,9 @@ logger = logging.getLogger("ntfy_notifier")
 
 class NtfyNotifierPlugin(ToolPlugin):
     name = "ntfy_notifier"
+    plugin_name = "ntfy Notifier"
     description = "Sends RSS announcements to an ntfy topic (self-hosted or ntfy.sh)."
+    plugin_dec = "Send RSS announcements to an ntfy topic."
     usage = ""
     platforms = []
     settings_category = "NTFY Notifier"

--- a/plugins/obsidian_note.py
+++ b/plugins/obsidian_note.py
@@ -22,8 +22,10 @@ class ObsidianNotePlugin(ToolPlugin):
     """
 
     name = "obsidian_note"
+    plugin_name = "Obsidian Note"
     pretty_name = "Add to Obsidian"
     description = "Always creates a new note with an AI-generated title at the vault root."
+    plugin_dec = "Create a new Obsidian note with an AI-generated title and content."
     usage = (
         "{\n"
         '  "function": "obsidian_note",\n'

--- a/plugins/obsidian_search.py
+++ b/plugins/obsidian_search.py
@@ -24,8 +24,10 @@ class ObsidianSearchPlugin(ToolPlugin):
     """
 
     name = "obsidian_search"
+    plugin_name = "Obsidian Search"
     pretty_name = "Search Obsidian"
     description = "Searches all notes in your vault. Extracts relevant info from each file and combines into one answer."
+    plugin_dec = "Search your Obsidian vault and summarize matching notes."
     usage = (
         "{\n"
         '  "function": "obsidian_search",\n'

--- a/plugins/overseerr_request.py
+++ b/plugins/overseerr_request.py
@@ -26,6 +26,7 @@ class OverseerrRequestPlugin(ToolPlugin):
       - request "Dune"
     """
     name = "overseerr_request"
+    plugin_name = "Overseerr Request"
     usage = (
         "{\n"
         '  "function": "overseerr_request",\n'
@@ -39,6 +40,7 @@ class OverseerrRequestPlugin(ToolPlugin):
         "Adds a movie or TV show to Overseerr by title, creating a new request for it. "
         "Example: add the movie F1, request the TV show One Piece, request the movie Dune."
     )
+    plugin_dec = "Request a movie or TV show in Overseerr by title."
     pretty_name = "Overseerr: Add Request"
     settings_category = "Overseerr"
     required_settings = {

--- a/plugins/overseerr_trending.py
+++ b/plugins/overseerr_trending.py
@@ -16,6 +16,7 @@ logger.setLevel(logging.INFO)
 
 class OverseerrTrendingPlugin(ToolPlugin):
     name = "overseerr_trending"
+    plugin_name = "Overseerr Trending"
     usage = (
         "{\n"
         '  "function": "overseerr_trending",\n'
@@ -31,6 +32,7 @@ class OverseerrTrendingPlugin(ToolPlugin):
         "You can ask for current trending or upcoming titles (e.g., 'what movies are trending', 'what TV shows are coming soon'), "
         "or request details about a specific movie or show (e.g., 'tell me about Dune 2'). "
     )
+    plugin_dec = "List trending or upcoming movies and shows from Overseerr and answer related questions."
     pretty_name = "Overseerr: Trending & Upcoming"
     settings_category = "Overseerr"
     required_settings = {

--- a/plugins/premiumize_download.py
+++ b/plugins/premiumize_download.py
@@ -13,6 +13,7 @@ logger.setLevel(logging.DEBUG)
 
 class PremiumizeDownloadPlugin(ToolPlugin):
     name = "premiumize_download"
+    plugin_name = "Premiumize Download"
     usage = (
         "{\n"
         '  "function": "premiumize_download",\n'
@@ -22,6 +23,7 @@ class PremiumizeDownloadPlugin(ToolPlugin):
     description = (
         "Checks if a link (HTTP/HTTPS or magnet) is cached on Premiumize.me and, if so, returns direct download links."
     )
+    plugin_dec = "Check if a link is cached on Premiumize and return direct download links."
     pretty_name = "Getting Links"
     settings_category = "Premiumize"
     required_settings = {

--- a/plugins/premiumize_torrent.py
+++ b/plugins/premiumize_torrent.py
@@ -21,6 +21,7 @@ logger.setLevel(logging.INFO)
 
 class PremiumizeTorrentPlugin(ToolPlugin):
     name = "premiumize_torrent"
+    plugin_name = "Premiumize Torrent"
     usage = (
         "{\n"
         '  "function": "premiumize_torrent",\n'
@@ -28,6 +29,7 @@ class PremiumizeTorrentPlugin(ToolPlugin):
         "}\n"
     )
     description = "Checks if a .torrent file in recent chat history is cached on Premiumize.me and returns direct links if available."
+    plugin_dec = "Check the latest torrent or magnet against Premiumize cache and provide direct links."
     pretty_name = "Getting Links"
     settings_category = "Premiumize"
     required_settings = {

--- a/plugins/sftpgo_account.py
+++ b/plugins/sftpgo_account.py
@@ -21,6 +21,7 @@ logger.setLevel(logging.INFO)
 
 class SFTPGoAccountPlugin(ToolPlugin):
     name = "sftpgo_account"
+    plugin_name = "SFTPGo Account"
     usage = (
         '{\n'
         '  "function": "sftpgo_account",\n'
@@ -28,6 +29,7 @@ class SFTPGoAccountPlugin(ToolPlugin):
         '}\n'
     )
     description = "Creates an SFTPGo account for the user and returns their credentials."
+    plugin_dec = "Create an SFTPGo account for the user and return login details."
     pretty_name = "Creating Account"
     settings_category = "SFTPGo"
     required_settings = {

--- a/plugins/sftpgo_activity.py
+++ b/plugins/sftpgo_activity.py
@@ -8,6 +8,7 @@ from plugin_base import ToolPlugin
 
 class SFTPGoActivityPlugin(ToolPlugin):
     name = "sftpgo_activity"
+    plugin_name = "SFTPGo Activity"
     usage = (
         '{\n'
         '  "function": "sftpgo_activity",\n'
@@ -15,6 +16,7 @@ class SFTPGoActivityPlugin(ToolPlugin):
         '}\n'
     )
     description = "Retrieves current connection activity from the SFTPGo server."
+    plugin_dec = "Show current connection activity on the SFTPGo server."
     pretty_name = "Checking FTP Activity"
     settings_category = "SFTPGo"
     waiting_prompt_template = "Write a friendly message telling {mention} you’re accessing the server to see who’s using it now! Only output that message."

--- a/plugins/tater_gits_add_feed.py
+++ b/plugins/tater_gits_add_feed.py
@@ -15,6 +15,7 @@ logger.setLevel(logging.INFO)
 
 class TaterGitsAddFeedPlugin(ToolPlugin):
     name = "tater_gits_add_feed"
+    plugin_name = "Tater Gits Add Feed"
     usage = (
         "{\n"
         '  "function": "tater_gits_add_feed",\n'
@@ -22,6 +23,7 @@ class TaterGitsAddFeedPlugin(ToolPlugin):
         "}\n"
     )
     description = "Adds a GitHub releases feed to the tater-gits watcher. Infers title prefix and category via LLM."
+    plugin_dec = "Add a GitHub releases feed to the tater-gits watcher with smart naming."
     pretty_name = "Add Git Feed"
     waiting_prompt_template = "Tell {mention} I’m analyzing that repo and adding the feed now. Output only that friendly message."
     platforms = ["webui", "discord", "irc", "matrix"]

--- a/plugins/telegram_notifier.py
+++ b/plugins/telegram_notifier.py
@@ -12,7 +12,9 @@ logger = logging.getLogger("telegram_notifier")
 
 class TelegramNotifierPlugin(ToolPlugin):
     name = "telegram_notifier"
+    plugin_name = "Telegram Notifier"
     description = "Provides Telegram bot token and chat ID settings for RSS announcements."
+    plugin_dec = "Send RSS summaries to a Telegram chat via bot token and chat ID."
     usage = ""
     platforms = []
     settings_category = "Telegram Notifier"

--- a/plugins/unwatch_feed.py
+++ b/plugins/unwatch_feed.py
@@ -16,6 +16,7 @@ redis_client = redis.Redis(host=redis_host, port=redis_port, db=0, decode_respon
 
 class UnwatchFeedPlugin(ToolPlugin):
     name = "unwatch_feed"
+    plugin_name = "Unwatch Feed"
     usage = (
         "{\n"
         '  "function": "unwatch_feed",\n'
@@ -23,6 +24,7 @@ class UnwatchFeedPlugin(ToolPlugin):
         "}\n"
     )
     description = "Removes an RSS feed provided by the user from the RSS watch list."
+    plugin_dec = "Remove an RSS feed from the watch list."
     pretty_name = "Unwatch RSS Feed"
     waiting_prompt_template = (
         "Write a friendly message telling {mention} you’re removing the feed from the watch list now! "

--- a/plugins/vision_describer.py
+++ b/plugins/vision_describer.py
@@ -32,6 +32,7 @@ def _to_data_url(image_bytes: bytes, filename: str = "image.png") -> str:
 
 class VisionDescriberPlugin(ToolPlugin):
     name = "vision_describer"
+    plugin_name = "Vision Describer"
     usage = (
         '{\n'
         '  "function": "vision_describer",\n'
@@ -42,6 +43,7 @@ class VisionDescriberPlugin(ToolPlugin):
         "Uses an OpenAI-compatible *vision* model to describe the most recent image. "
         "No input needed — it automatically finds the latest uploaded or generated image."
     )
+    plugin_dec = "Describe the most recent image using a vision-capable model."
     pretty_name = "Describing Your Image"
     settings_category = "Vision"
     required_settings = {

--- a/plugins/voicepe_remote_timer.py
+++ b/plugins/voicepe_remote_timer.py
@@ -29,6 +29,7 @@ class VoicePERemoteTimerPlugin(ToolPlugin):
     """
 
     name = "voicepe_remote_timer"
+    plugin_name = "Voice PE Remote Timer"
     pretty_name = "Voice PE Remote Timer"
     settings_category = "Voice PE Remote Timer"
 
@@ -48,6 +49,7 @@ class VoicePERemoteTimerPlugin(ToolPlugin):
         "If duration is omitted, reports remaining time. "
         "If action is 'cancel', cancels the current timer."
     )
+    plugin_dec = "Start, cancel, or check a Voice PE (ESPHome) timer device."
 
     required_settings = {
         "HA_BASE_URL": {

--- a/plugins/watch_feed.py
+++ b/plugins/watch_feed.py
@@ -19,6 +19,7 @@ redis_client = redis.Redis(host=redis_host, port=redis_port, db=0, decode_respon
 
 class WatchFeedPlugin(ToolPlugin):
     name = "watch_feed"
+    plugin_name = "Watch Feed"
     usage = (
         "{\n"
         '  "function": "watch_feed",\n'
@@ -26,6 +27,7 @@ class WatchFeedPlugin(ToolPlugin):
         "}\n"
     )
     description = "Adds an RSS/Atom feed to the watch list and records the latest seen item so future checks only post new entries."
+    plugin_dec = "Add an RSS/Atom feed to the watch list and track new items."
     pretty_name = "Adding Your Feed"
     waiting_prompt_template = (
         "Write a friendly message telling {mention} you’re adding the feed to the watch list now! "

--- a/plugins/weather_brief.py
+++ b/plugins/weather_brief.py
@@ -25,12 +25,14 @@ class WeatherBriefPlugin(ToolPlugin):
     Optional: write the result directly into an input_text helper in HA.
     """
     name = "weather_brief"
+    plugin_name = "Weather Brief"
     pretty_name = "Weather Brief"
 
     description = (
         "Automation-only: returns a very short summary of recent weather conditions "
         "(temperature, wind, rain) over the last N hours using Home Assistant sensors."
     )
+    plugin_dec = "Give a short automation-friendly recap of recent weather conditions."
 
     usage = (
         "{\n"

--- a/plugins/web_search.py
+++ b/plugins/web_search.py
@@ -19,6 +19,7 @@ logger.setLevel(logging.INFO)
 
 class WebSearchPlugin(ToolPlugin):
     name = "web_search"
+    plugin_name = "Web Search"
     usage = (
         "{\n"
         '  "function": "web_search",\n'
@@ -26,6 +27,7 @@ class WebSearchPlugin(ToolPlugin):
         "}\n"
     )
     description = "Web search tool, search for more info to help answer the users questions."
+    plugin_dec = "Search the web via Google CSE and summarize a relevant result."
     pretty_name = "Searching For More Info"
     settings_category = "Web Search"
     required_settings = {

--- a/plugins/web_summary.py
+++ b/plugins/web_summary.py
@@ -14,6 +14,7 @@ logger.setLevel(logging.INFO)
 
 class WebSummaryPlugin(ToolPlugin):
     name = "web_summary"
+    plugin_name = "Web Summary"
     usage = (
         "{\n"
         '  "function": "web_summary",\n'
@@ -21,6 +22,7 @@ class WebSummaryPlugin(ToolPlugin):
         "}\n"
     )
     description = "Summarizes an article from a URL provided by the user."
+    plugin_dec = "Summarize the main points of a webpage from its URL."
     pretty_name = "Summarizing Your Article"
     waiting_prompt_template = "Write a casual, friendly message telling {mention} you’re reading the article and preparing a summary now! Only output that message."
     platforms = ["discord", "webui", "irc", "matrix"]

--- a/plugins/webdav_browser.py
+++ b/plugins/webdav_browser.py
@@ -18,6 +18,7 @@ async def safe_send(channel, content: str, **kwargs):
 
 class WebDAVBrowserPlugin(ToolPlugin):
     name = "webdav_browser"
+    plugin_name = "WebDAV Browser"
     usage = (
         "{\n"
         '  "function": "webdav_browser",\n'
@@ -25,6 +26,7 @@ class WebDAVBrowserPlugin(ToolPlugin):
         "}\n"
     )
     description = "Lets the user browse and download files from the WebDAV server."
+    plugin_dec = "Browse and download files from the configured WebDAV server."
     pretty_name = "Connecting to WebDAV"
     settings_category = "WebDAV Browser"
     platforms = ["discord"]

--- a/plugins/wordpress_poster.py
+++ b/plugins/wordpress_poster.py
@@ -10,9 +10,11 @@ from plugin_settings import get_plugin_enabled, get_plugin_settings
 
 class WordPressPosterPlugin(ToolPlugin):
     name = "wordpress_poster"
+    plugin_name = "WordPress Poster"
     platforms = []
     usage = ""
     description = "Posts RSS summaries to WordPress using its REST API."
+    plugin_dec = "Post RSS summaries to a WordPress site via its REST API."
     settings_category = "WordPress Poster"
     notifier = True
 

--- a/plugins/youtube_summary.py
+++ b/plugins/youtube_summary.py
@@ -20,6 +20,7 @@ DEFAULT_MAX_TOKENS = 2048
 
 class YouTubeSummaryPlugin(ToolPlugin):
     name = "youtube_summary"
+    plugin_name = "YouTube Summary"
     usage = (
         '{\n'
         '  "function": "youtube_summary",\n'
@@ -29,6 +30,7 @@ class YouTubeSummaryPlugin(ToolPlugin):
         '}'
     )
     description = "Summarizes a YouTube video using its transcript."
+    plugin_dec = "Summarize a YouTube video using its transcript."
     pretty_name = "Summarizing Your Video"
     settings_category = "YouTube Summary"
     required_settings = {

--- a/plugins/zen_greeting.py
+++ b/plugins/zen_greeting.py
@@ -26,12 +26,14 @@ class ZenGreetingPlugin(ToolPlugin):
     - Uses HA time sensor so the greeting matches HA's local time.
     """
     name = "zen_greeting"
+    plugin_name = "Zen Greeting"
     pretty_name = "Zen Greeting"
 
     description = (
         "Automation-only: creates a short, calming greeting and zen message of the day. "
         "Uses the LLM so the message varies a bit each run. Designed for dashboards."
     )
+    plugin_dec = "Generate a calming daily greeting and message for dashboards."
 
     usage = (
         "{\n"

--- a/webui.py
+++ b/webui.py
@@ -228,9 +228,9 @@ def get_plugin_enabled(plugin_name):
 def set_plugin_enabled(plugin_name, enabled):
     redis_client.hset("plugin_enabled", plugin_name, "true" if enabled else "false")
 
-def render_plugin_controls(plugin_name):
+def render_plugin_controls(plugin_name, label=None):
     current_state = get_plugin_enabled(plugin_name)
-    toggle_state = st.toggle(plugin_name, value=current_state, key=f"plugin_toggle_{plugin_name}")
+    toggle_state = st.toggle(label or plugin_name, value=current_state, key=f"plugin_toggle_{plugin_name}")
 
     if toggle_state != current_state:
         set_plugin_enabled(plugin_name, toggle_state)
@@ -404,68 +404,51 @@ def save_plugin_settings(category, settings_dict):
     str_settings = {k: str(v) for k, v in settings_dict.items()}
     redis_client.hset(key, mapping=str_settings)
 
-# Updated: Gather distinct plugin settings categories from the plugin registry,
-# only including plugins that are enabled.
-plugin_categories = {}
+def get_plugin_description(plugin):
+    return getattr(plugin, "plugin_dec", None) or getattr(plugin, "description", "")
 
-for plugin in plugin_registry.values():
-    if not get_plugin_enabled(plugin.name):
-        continue
+def render_plugin_settings_form(plugin):
+    category = getattr(plugin, "settings_category", None)
+    settings = getattr(plugin, "required_settings", None) or {}
+    if not category or not settings:
+        return
 
-    cat = getattr(plugin, "settings_category", None)
-    settings = getattr(plugin, "required_settings", None)
-
-    if not cat or not settings:
-        continue  # Skip plugins with no settings UI
-
-    if cat not in plugin_categories:
-        plugin_categories[cat] = {}
-
-    plugin_categories[cat].update(settings)
-
-# Display an expander for each plugin settings category.
-for category, settings in sorted(plugin_categories.items()):
-    with st.sidebar.expander(category, expanded=False):
-        st.subheader(f"{category} Settings")
+    with st.expander("Settings", expanded=False):
         current_settings = get_plugin_settings(category)
         new_settings = {}
+        has_fields = False
 
         for key, info in settings.items():
             input_type    = info.get("type", "text")
+            label         = info.get("label", key)
+            desc          = info.get("description", "")
             default_value = current_settings.get(key, info.get("default", ""))
 
-            # --- BUTTONS go first ---
             if input_type == "button":
-                if st.button(info["label"], key=f"{category}_{key}_button"):
-                    plugin_obj = next(
-                        (p for p in plugin_registry.values()
-                         if getattr(p, "settings_category", "") == category),
-                        None
-                    )
-                    if plugin_obj and hasattr(plugin_obj, "handle_setting_button"):
-                        result = plugin_obj.handle_setting_button(key)
+                if st.button(label, key=f"{plugin.name}_{category}_{key}_button"):
+                    if hasattr(plugin, "handle_setting_button"):
+                        result = plugin.handle_setting_button(key)
                         if result:
                             st.success(result)
-                if info.get("description"):
-                    st.caption(info["description"])
-                continue  # skip saving a value for buttons
+                if desc:
+                    st.caption(desc)
+                continue
 
-            # PASSWORD
+            has_fields = True
+
             if input_type == "password":
                 new_value = st.text_input(
-                    info.get("label", key),
-                    value=default_value,
-                    help=info.get("description", ""),
+                    label,
+                    value=str(default_value),
+                    help=desc,
                     type="password",
-                    key=f"{category}_{key}"
+                    key=f"{plugin.name}_{category}_{key}"
                 )
-
-            # FILE
             elif input_type == "file":
                 uploaded_file = st.file_uploader(
-                    info.get("label", key),
+                    label,
                     type=["json"],
-                    key=f"{category}_{key}"
+                    key=f"{plugin.name}_{category}_{key}"
                 )
                 if uploaded_file is not None:
                     try:
@@ -477,46 +460,222 @@ for category, settings in sorted(plugin_categories.items()):
                         new_value = default_value
                 else:
                     new_value = default_value
-
-            # SELECT
             elif input_type == "select":
                 options = info.get("options", []) or ["Option 1", "Option 2"]
                 current_index = options.index(default_value) if default_value in options else 0
                 new_value = st.selectbox(
-                    info.get("label", key),
+                    label,
                     options,
                     index=current_index,
-                    help=info.get("description", ""),
-                    key=f"{category}_{key}"
+                    help=desc,
+                    key=f"{plugin.name}_{category}_{key}"
                 )
-
-            # CHECKBOX
             elif input_type == "checkbox":
                 is_checked = (
                     default_value if isinstance(default_value, bool)
                     else str(default_value).lower() in ("true", "1", "yes")
                 )
                 new_value = st.checkbox(
-                    info.get("label", key),
+                    label,
                     value=is_checked,
-                    help=info.get("description", ""),
-                    key=f"{category}_{key}"
+                    help=desc,
+                    key=f"{plugin.name}_{category}_{key}"
                 )
-
-            # TEXT (fallback)
+            elif input_type == "number":
+                raw_value = str(default_value).strip()
+                is_int_like = bool(re.fullmatch(r"-?\d+", raw_value))
+                if is_int_like:
+                    try:
+                        current_num = int(raw_value)
+                    except Exception:
+                        current_num = 0
+                    new_value = st.number_input(
+                        label,
+                        value=current_num,
+                        step=1,
+                        format="%d",
+                        help=desc,
+                        key=f"{plugin.name}_{category}_{key}"
+                    )
+                else:
+                    try:
+                        current_num = float(raw_value) if raw_value else 0.0
+                    except Exception:
+                        current_num = 0.0
+                    new_value = st.number_input(
+                        label,
+                        value=current_num,
+                        step=1.0,
+                        help=desc,
+                        key=f"{plugin.name}_{category}_{key}"
+                    )
             else:
                 new_value = st.text_input(
-                    info.get("label", key),
-                    value=default_value,
-                    help=info.get("description", ""),
-                    key=f"{category}_{key}"  # 🔹 unique per plugin+setting
+                    label,
+                    value=str(default_value),
+                    help=desc,
+                    key=f"{plugin.name}_{category}_{key}"
                 )
 
             new_settings[key] = new_value
 
-        if st.button(f"Save {category} Settings", key=f"save_{category}_unique"):
+        if has_fields and st.button(f"Save {category} Settings", key=f"save_{plugin.name}_{category}"):
             save_plugin_settings(category, new_settings)
             st.success(f"{category} settings saved.")
+            st.rerun()
+
+def render_plugin_card(plugin):
+    display_name = getattr(plugin, "plugin_name", None) or getattr(plugin, "pretty_name", None) or plugin.name
+    description = get_plugin_description(plugin)
+    platforms = getattr(plugin, "platforms", []) or []
+
+    with st.container(border=True):
+        header_cols = st.columns([4, 1])
+        with header_cols[0]:
+            st.subheader(display_name)
+            st.caption(f"ID: {plugin.name}")
+        with header_cols[1]:
+            render_plugin_controls(plugin.name, label="Enabled")
+
+        st.write(description)
+        if platforms:
+            st.caption(f"Platforms: {', '.join(platforms)}")
+
+        render_plugin_settings_form(plugin)
+
+def render_platforms_panel(auto_connected=None):
+    st.subheader("Platforms")
+    if auto_connected:
+        st.success(f"{', '.join(auto_connected)} auto-connected.")
+    for platform in sorted(platform_registry, key=lambda p: p["category"].lower()):
+        label = platform["label"]
+        with st.expander(label, expanded=False):
+            render_platform_controls(platform, redis_client)
+
+def render_webui_settings():
+    st.subheader("WebUI Settings")
+    current_chat = get_chat_settings()
+    username = st.text_input("Username", value=current_chat["username"], key="webui_username")
+
+    raw_display = redis_client.get("tater:max_display") or 8
+    try:
+        display_count = int(float(raw_display))
+    except (TypeError, ValueError):
+        display_count = 8
+
+    new_display = st.number_input(
+        "Messages Shown in WebUI",
+        min_value=1,
+        max_value=500,
+        value=display_count,
+        step=1,
+        format="%d",
+        key="webui_display_count"
+    )
+
+    show_speed_default = (redis_client.get("tater:show_speed_stats") or "true").lower() == "true"
+    show_speed = st.checkbox("Show tokens/sec", value=show_speed_default, key="show_speed_stats")
+
+    uploaded_avatar = st.file_uploader(
+        "Upload your avatar", type=["png", "jpg", "jpeg"], key="avatar_uploader"
+    )
+
+    if st.button("Save WebUI Settings", key="save_webui_settings"):
+        if uploaded_avatar is not None:
+            avatar_bytes = uploaded_avatar.read()
+            avatar_b64 = base64.b64encode(avatar_bytes).decode("utf-8")
+            save_chat_settings(username, avatar_b64)
+        else:
+            save_chat_settings(username)
+
+        redis_client.set("tater:max_display", new_display)
+        redis_client.set("tater:show_speed_stats", "true" if show_speed else "false")
+        st.success("WebUI settings updated.")
+
+    col1, col2 = st.columns(2)
+    with col1:
+        if st.button("Clear Chat History", key="clear_history"):
+            clear_chat_history()
+            st.success("Chat history cleared.")
+    with col2:
+        if st.button("Clear Active Plugin Jobs", key="clear_plugin_jobs"):
+            for key in redis_client.scan_iter("webui:plugin_jobs:*"):
+                redis_client.delete(key)
+            st.success("All active plugin jobs have been cleared.")
+            st.rerun()
+
+def render_tater_settings():
+    st.subheader(f"{first_name} Settings")
+    stored_count = int(redis_client.get("tater:max_store") or 20)
+    llm_count = int(redis_client.get("tater:max_llm") or 8)
+    default_first = redis_client.get("tater:first_name") or first_name
+    default_last = redis_client.get("tater:last_name") or last_name
+    default_personality = redis_client.get("tater:personality") or ""
+
+    first_input = st.text_input("First Name", value=default_first, key="tater_first_name")
+    last_input = st.text_input("Last Name", value=default_last, key="tater_last_name")
+
+    personality_input = st.text_area(
+        "Personality / Style (optional)",
+        value=default_personality,
+        help=(
+            "Describe how you want Tater to talk and behave. "
+            "Examples:\n"
+            "- A calm and confident starship captain.\n"
+            "- Captain Jahn-Luek Picard of the Starship Enterprise.\n"
+            "- A laid-back hippy stoner who still explains things clearly."
+        ),
+        height=120,
+        key="tater_personality"
+    )
+
+    uploaded_tater_avatar = st.file_uploader(
+        f"Upload {first_input}'s avatar", type=["png", "jpg", "jpeg"], key="tater_avatar_uploader"
+    )
+    if uploaded_tater_avatar is not None:
+        avatar_bytes = uploaded_tater_avatar.read()
+        avatar_b64 = base64.b64encode(avatar_bytes).decode("utf-8")
+        redis_client.set("tater:avatar", avatar_b64)
+
+    new_store = st.number_input("Max Stored Messages (0 = unlimited)", min_value=0, value=stored_count, key="tater_store_limit")
+    if new_store == 0:
+        st.warning("⚠️ Unlimited history enabled — this may grow Redis memory usage over time.")
+    new_llm = st.number_input("Messages Sent to LLM", min_value=1, value=llm_count, key="tater_llm_limit")
+    if new_store > 0 and new_llm > new_store:
+        st.warning("⚠️ You're trying to send more messages to LLM than you’re storing. Consider increasing Max Stored Messages.")
+
+    if st.button("Save Tater Settings", key="save_tater_settings"):
+        redis_client.set("tater:max_store", new_store)
+        redis_client.set("tater:max_llm", new_llm)
+        redis_client.set("tater:first_name", first_input)
+        redis_client.set("tater:last_name", last_input)
+        redis_client.set("tater:personality", personality_input)
+        st.success("Tater settings updated.")
+        st.rerun()
+
+def render_settings_page():
+    st.title("Settings")
+    render_webui_settings()
+    st.markdown("---")
+    render_tater_settings()
+
+def _sort_plugins_for_display(plugins):
+    return sorted(
+        plugins,
+        key=lambda p: (
+            getattr(p, "plugin_name", None)
+            or getattr(p, "pretty_name", None)
+            or p.name
+        ).lower()
+    )
+
+def render_plugin_list(plugins, empty_message):
+    sorted_plugins = _sort_plugins_for_display(plugins)
+    if not sorted_plugins:
+        st.info(empty_message)
+        return
+    for plugin in sorted_plugins:
+        render_plugin_card(plugin)
 
 # ----------------- SYSTEM PROMPT -----------------
 def build_system_prompt():
@@ -819,124 +978,25 @@ async def process_function_call(response_json, user_question=""):
     else:
         return "Received an unknown function call."
 
-# ------------------ SIDEBAR EXPANDERS ------------------
+# ------------------ NAVIGATION ------------------
+nav_options = ["Chat", "Plugins", "Auto Plugins", "Platforms", "Settings"]
+if "active_view" not in st.session_state:
+    st.session_state.active_view = nav_options[0]
+
+st.sidebar.markdown("**Navigation**")
+for opt in nav_options:
+    if st.sidebar.button(opt, use_container_width=True, key=f"nav_btn_{opt}"):
+        st.session_state.active_view = opt
+        st.rerun()
+
+active_view = st.session_state.active_view
 st.sidebar.markdown("---")
-
-with st.sidebar.expander("Plugin Settings", expanded=False):
-    st.subheader("Enable/Disable Plugins")
-    for plugin_name in sorted(plugin_registry.keys(), key=lambda n: n.lower()):
-        render_plugin_controls(plugin_name)
-
-for platform in sorted(platform_registry, key=lambda p: p["category"].lower()):
-    label = platform["label"]
-    with st.sidebar.expander(label, expanded=False):
-        render_platform_controls(platform, redis_client)
-
-with st.sidebar.expander("WebUI Settings", expanded=False):
-    st.subheader("WebUI Settings")
-    current_chat = get_chat_settings()
-    username = st.text_input("USERNAME", value=current_chat["username"])
-
-    # safely cast to int — handles strings or floats in Redis
-    raw_display = redis_client.get("tater:max_display") or 8
-    try:
-        display_count = int(float(raw_display))
-    except (TypeError, ValueError):
-        display_count = 8
-
-    # number input with integer step & format
-    new_display = st.number_input(
-        "Messages Shown in WebUI",
-        min_value=1,
-        max_value=500,
-        value=display_count,
-        step=1,
-        format="%d",
-        key="webui_display_count"
-    )
-
-    show_speed_default = (redis_client.get("tater:show_speed_stats") or "true").lower() == "true"
-    show_speed = st.checkbox("Show tokens/sec", value=show_speed_default, key="show_speed_stats")
-
-    uploaded_avatar = st.file_uploader(
-        "Upload your avatar", type=["png", "jpg", "jpeg"], key="avatar_uploader"
-    )
-
-    if uploaded_avatar is not None:
-        avatar_bytes = uploaded_avatar.read()
-        avatar_b64 = base64.b64encode(avatar_bytes).decode("utf-8")
-        save_chat_settings(username, avatar_b64)
-    else:
-        save_chat_settings(username)
-
-    if st.button("Save WebUI Settings", key="save_webui_settings"):
-        redis_client.set("tater:max_display", new_display)
-        redis_client.set("tater:show_speed_stats", "true" if show_speed else "false")
-        st.success("WebUI settings updated.")
-
-    if st.button("Clear Chat History", key="clear_history"):
-        clear_chat_history()
-        st.success("Chat history cleared.")
-
-    if st.button("Clear Active Plugin Jobs", key="clear_plugin_jobs"):
-        for key in redis_client.scan_iter("webui:plugin_jobs:*"):
-            redis_client.delete(key)
-        st.success("All active plugin jobs have been cleared.")
-        st.rerun()
-
-with st.sidebar.expander(f"{first_name} Settings", expanded=False):
-    st.subheader("Tater Runtime Configuration")
-    stored_count = int(redis_client.get("tater:max_store") or 20)
-    llm_count = int(redis_client.get("tater:max_llm") or 8)
-    default_first = redis_client.get("tater:first_name") or first_name
-    default_last = redis_client.get("tater:last_name") or last_name
-    default_personality = redis_client.get("tater:personality") or ""
-
-    first_input = st.text_input("First Name", value=default_first)
-    last_input = st.text_input("Last Name", value=default_last)
-
-    # New: personality/style field
-    personality_input = st.text_area(
-        "Personality / Style (optional)",
-        value=default_personality,
-        help=(
-            "Describe how you want Tater to talk and behave. "
-            "Examples:\n"
-            "- A calm and confident starship captain.\n"
-            "- Captain Jahn-Luek Picard of the Starship Enterprise.\n"
-            "- A laid-back hippy stoner who still explains things clearly."
-        ),
-        height=120,
-    )
-
-    uploaded_tater_avatar = st.file_uploader(
-        f"Upload {first_input}'s avatar", type=["png", "jpg", "jpeg"], key="tater_avatar_uploader"
-    )
-    if uploaded_tater_avatar is not None:
-        avatar_bytes = uploaded_tater_avatar.read()
-        avatar_b64 = base64.b64encode(avatar_bytes).decode("utf-8")
-        redis_client.set("tater:avatar", avatar_b64)
-
-    new_store = st.number_input("Max Stored Messages (0 = unlimited)", min_value=0, value=stored_count)
-    if new_store == 0:
-        st.warning("⚠️ Unlimited history enabled — this may grow Redis memory usage over time.")
-    new_llm = st.number_input("Messages Sent to LLM", min_value=1, value=llm_count)
-    if new_store > 0 and new_llm > new_store:
-        st.warning("⚠️ You're trying to send more messages to LLM than you’re storing. Consider increasing Max Stored Messages.")
-
-    if st.button("Save Tater Settings"):
-        redis_client.set("tater:max_store", new_store)
-        redis_client.set("tater:max_llm", new_llm)
-        redis_client.set("tater:first_name", first_input)
-        redis_client.set("tater:last_name", last_input)
-        redis_client.set("tater:personality", personality_input)
-        st.success("Tater settings updated.")
-        st.rerun()
 
 # ------------------ RSS ------------------
 _start_rss(llm_client)
 
 # ------------------ PLATFORM MANAGEMENT ------------------
+auto_connected = []
 for platform in platform_registry:
     key = platform["key"]  # e.g. irc_platform
     state_key = f"{key}_running"
@@ -946,15 +1006,19 @@ for platform in platform_registry:
 
     if platform_should_run:
         _start_platform(key)
-        st.success(f"{platform['category']} auto-connected.")
+        auto_connected.append(platform["category"])
 
-# ------------------ Chat ------------------
-st.title(f"{first_name} Chat Web UI")
+# Prepare plugin groupings
+automation_plugins = _sort_plugins_for_display([
+    p for p in plugin_registry.values()
+    if set(getattr(p, "platforms", []) or []) == {"automation"}
+])
+regular_plugins = _sort_plugins_for_display([
+    p for p in plugin_registry.values()
+    if set(getattr(p, "platforms", []) or []) != {"automation"}
+])
 
-chat_settings = get_chat_settings()
-avatar_b64  = chat_settings.get("avatar")
-user_avatar = load_avatar_image(avatar_b64) if avatar_b64 else None
-
+# Ensure chat history is available for any view
 if "chat_messages" not in st.session_state:
     full_history = load_chat_history()
     max_display = int(redis_client.get("tater:max_display") or 8)
@@ -989,168 +1053,170 @@ if job_keys:
 
             redis_client.delete(key)
 
-# Render all messages from session state
-for msg in st.session_state.chat_messages:
-    role = msg["role"]
-    avatar = user_avatar if role == "user" else assistant_avatar
-    content = msg["content"]
+if active_view == "Chat":
+    st.title(f"{first_name} Chat Web UI")
 
-    # Unwrap plugin_response and plugin_wait to their text payloads
-    while isinstance(content, dict) and content.get("marker") in ("plugin_response", "plugin_wait"):
-        content = content.get("content")
+    chat_settings = get_chat_settings()
+    avatar_b64  = chat_settings.get("avatar")
+    user_avatar = load_avatar_image(avatar_b64) if avatar_b64 else None
 
-    # 🔧 After unwrap, check for plugin_call marker and skip render if needed
-    if isinstance(content, dict) and content.get("marker") == "plugin_call":
-        continue
+    for msg in st.session_state.chat_messages:
+        role = msg["role"]
+        avatar = user_avatar if role == "user" else assistant_avatar
+        content = msg["content"]
 
-    with st.chat_message(role, avatar=avatar):
-        if isinstance(content, dict) and content.get("type") == "image":
-            if content.get("mimetype") == "image/webp":
-                st.markdown(
-                    f'''
-                    <img src="data:image/webp;base64,{content["data"]}"
-                         alt="{content.get("name", "")}"
-                         style="max-width: 100%; border-radius: 0.5rem;" autoplay loop>
-                    ''',
-                    unsafe_allow_html=True
-                )
-            else:
+        while isinstance(content, dict) and content.get("marker") in ("plugin_response", "plugin_wait"):
+            content = content.get("content")
+
+        if isinstance(content, dict) and content.get("marker") == "plugin_call":
+            continue
+
+        with st.chat_message(role, avatar=avatar):
+            if isinstance(content, dict) and content.get("type") == "image":
+                if content.get("mimetype") == "image/webp":
+                    st.markdown(
+                        f'''
+                        <img src="data:image/webp;base64,{content["data"]}"
+                             alt="{content.get("name", "")}"
+                             style="max-width: 100%; border-radius: 0.5rem;" autoplay loop>
+                        ''',
+                        unsafe_allow_html=True
+                    )
+                else:
+                    data = base64.b64decode(content["data"])
+                    st.image(Image.open(BytesIO(data)), caption=content.get("name", ""))
+
+            elif isinstance(content, dict) and content.get("type") == "audio":
                 data = base64.b64decode(content["data"])
-                st.image(Image.open(BytesIO(data)), caption=content.get("name", ""))
+                st.audio(data, format=content.get("mimetype", "audio/mpeg"))
 
-        elif isinstance(content, dict) and content.get("type") == "audio":
-            data = base64.b64decode(content["data"])
-            st.audio(data, format=content.get("mimetype", "audio/mpeg"))
+            elif isinstance(content, dict) and content.get("type") == "video":
+                data = base64.b64decode(content["data"])
+                st.video(data, format=content.get("mimetype", "video/mp4"))
 
-        elif isinstance(content, dict) and content.get("type") == "video":
-            data = base64.b64decode(content["data"])
-            st.video(data, format=content.get("mimetype", "video/mp4"))
+            else:
+                st.write(content)
 
-        else:
-            st.write(content)
+    if user_input := st.chat_input(f"Chat with {first_name}…"):
+        uname = chat_settings["username"]
 
-if user_input := st.chat_input(f"Chat with {first_name}…"):
-    uname = chat_settings["username"]
-
-    # Save and append user message right away
-    save_message("user", uname, user_input)
-    st.session_state.chat_messages.append({
-        "role": "user",
-        "content": user_input
-    })
-
-    # Show user's message immediately for feedback
-    st.chat_message("user", avatar=user_avatar or "🦖").write(user_input)
-
-    # Show spinner while thinking
-    with st.spinner(f"{first_name} is thinking..."):
-        response_text = run_async(process_message(uname, user_input))
-
-    func_call = parse_function_json(response_text)
-    if func_call:
-        func_result = run_async(process_function_call(func_call, user_input))
-        responses = func_result if isinstance(func_result, list) else [func_result]
-    else:
-        responses = [response_text]
-
-    # Just append assistant responses — no immediate rendering
-    for item in responses:
+        save_message("user", uname, user_input)
         st.session_state.chat_messages.append({
-            "role": "assistant",
-            "content": item
+            "role": "user",
+            "content": user_input
         })
-        save_message("assistant", "assistant", item)
 
-    # Force rerun, assistant reply will render on next pass
-    st.rerun()
+        st.chat_message("user", avatar=user_avatar or "🦖").write(user_input)
 
-# --- Tokens/sec & latency ---
-if (redis_client.get("tater:show_speed_stats") or "true").lower() == "true":
-    stats = redis_client.hgetall("webui:last_llm_stats")
-    if stats:
-        try:
-            model = stats.get("model") or "LLM"
-            elapsed = float(stats.get("elapsed", "0"))
-            prompt_tokens = int(stats.get("prompt_tokens", "0"))
-            completion_tokens = int(stats.get("completion_tokens", "0"))
-            total_tokens = int(stats.get("total_tokens", "0"))
-            tps_total = float(stats.get("tps_total", "0"))
-            tps_comp_str = stats.get("tps_comp") or ""
-            comp_part = f" | completion: {tps_comp_str} tok/s" if tps_comp_str else ""
-            st.caption(
-                f"⚡️ {model} — {tps_total:.0f} tok/s{comp_part} • "
-                f"{total_tokens} tok in {elapsed:.2f}s (prompt {prompt_tokens}, completion {completion_tokens})"
-            )
-        except Exception:
-            pass
+        with st.spinner(f"{first_name} is thinking..."):
+            response_text = run_async(process_message(uname, user_input))
 
-# ---------------- Pending jobs spinner with transition-based refresh ----------------
-# Gather pending plugin names for the UI label (same behavior, fewer Redis round trips)
+        func_call = parse_function_json(response_text)
+        if func_call:
+            func_result = run_async(process_function_call(func_call, user_input))
+            responses = func_result if isinstance(func_result, list) else [func_result]
+        else:
+            responses = [response_text]
 
-pending_plugins = []
-pending_keys = set()
-
-# Grab job keys once
-job_keys = list(redis_client.scan_iter(match="webui:plugin_jobs:*", count=2000))
-
-if job_keys:
-    # Pipeline: fetch status + plugin for each key in one round trip
-    pipe = redis_client.pipeline()
-    for key in job_keys:
-        pipe.hget(key, "status")
-        pipe.hget(key, "plugin")
-    results = pipe.execute()
-
-    # results comes back as [status0, plugin0, status1, plugin1, ...]
-    for i, key in enumerate(job_keys):
-        status = results[i * 2]
-        plugin_name = results[i * 2 + 1]
-
-        if status == "pending":
-            pending_keys.add(key)
-
-            if plugin_name and plugin_name in plugin_registry:
-                plugin = plugin_registry[plugin_name]
-                display_name = getattr(plugin, "pretty_name", plugin.name)
-                pending_plugins.append(display_name)
-            elif plugin_name:
-                pending_plugins.append(plugin_name)
-
-# If any are pending, show spinner and poll for either
-if pending_plugins:
-    names_str = ", ".join(pending_plugins)
-    with st.spinner(f"{first_name} is working on: {names_str}"):
-        previous_pending = set(pending_keys)
-        while True:
-            transition_detected = False
-            current_pending = set()
-
-            # Re-scan keys (same behavior as before)
-            job_keys = list(redis_client.scan_iter(match="webui:plugin_jobs:*", count=2000))
-            if job_keys:
-                pipe = redis_client.pipeline()
-                for key in job_keys:
-                    pipe.hget(key, "status")
-                statuses = pipe.execute()
-
-                for key, status in zip(job_keys, statuses):
-                    if status == "pending":
-                        current_pending.add(key)
-                    else:
-                        if key in previous_pending:
-                            transition_detected = True
-
-            # safety: handle vanished keys too
-            for key in list(previous_pending):
-                if not redis_client.exists(key):
-                    transition_detected = True
-
-            if transition_detected:
-                break
-            if not current_pending:
-                break
-
-            previous_pending = current_pending
-            time.sleep(1)
+        for item in responses:
+            st.session_state.chat_messages.append({
+                "role": "assistant",
+                "content": item
+            })
+            save_message("assistant", "assistant", item)
 
         st.rerun()
+
+    if (redis_client.get("tater:show_speed_stats") or "true").lower() == "true":
+        stats = redis_client.hgetall("webui:last_llm_stats")
+        if stats:
+            try:
+                model = stats.get("model") or "LLM"
+                elapsed = float(stats.get("elapsed", "0"))
+                prompt_tokens = int(stats.get("prompt_tokens", "0"))
+                completion_tokens = int(stats.get("completion_tokens", "0"))
+                total_tokens = int(stats.get("total_tokens", "0"))
+                tps_total = float(stats.get("tps_total", "0"))
+                tps_comp_str = stats.get("tps_comp") or ""
+                comp_part = f" | completion: {tps_comp_str} tok/s" if tps_comp_str else ""
+                st.caption(
+                    f"⚡️ {model} — {tps_total:.0f} tok/s{comp_part} • "
+                    f"{total_tokens} tok in {elapsed:.2f}s (prompt {prompt_tokens}, completion {completion_tokens})"
+                )
+            except Exception:
+                pass
+
+    pending_plugins = []
+    pending_keys = set()
+    job_keys = list(redis_client.scan_iter(match="webui:plugin_jobs:*", count=2000))
+
+    if job_keys:
+        pipe = redis_client.pipeline()
+        for key in job_keys:
+            pipe.hget(key, "status")
+            pipe.hget(key, "plugin")
+        results = pipe.execute()
+
+        for i, key in enumerate(job_keys):
+            status = results[i * 2]
+            plugin_name = results[i * 2 + 1]
+
+            if status == "pending":
+                pending_keys.add(key)
+
+                if plugin_name and plugin_name in plugin_registry:
+                    plugin = plugin_registry[plugin_name]
+                    display_name = getattr(plugin, "plugin_name", None) or getattr(plugin, "pretty_name", None) or plugin.name
+                    pending_plugins.append(display_name)
+                elif plugin_name:
+                    pending_plugins.append(plugin_name)
+
+    if pending_plugins:
+        names_str = ", ".join(pending_plugins)
+        with st.spinner(f"{first_name} is working on: {names_str}"):
+            previous_pending = set(pending_keys)
+            while True:
+                transition_detected = False
+                current_pending = set()
+
+                job_keys = list(redis_client.scan_iter(match="webui:plugin_jobs:*", count=2000))
+                if job_keys:
+                    pipe = redis_client.pipeline()
+                    for key in job_keys:
+                        pipe.hget(key, "status")
+                    statuses = pipe.execute()
+
+                    for key, status in zip(job_keys, statuses):
+                        if status == "pending":
+                            current_pending.add(key)
+                        else:
+                            if key in previous_pending:
+                                transition_detected = True
+
+                for key in list(previous_pending):
+                    if not redis_client.exists(key):
+                        transition_detected = True
+
+                if transition_detected:
+                    break
+                if not current_pending:
+                    break
+
+                previous_pending = current_pending
+                time.sleep(1)
+
+            st.rerun()
+
+elif active_view == "Plugins":
+    st.title("Plugins")
+    st.write("Browse available plugins. Automation-only tools are listed separately.")
+    render_plugin_list(regular_plugins, "No plugins available.")
+elif active_view == "Auto Plugins":
+    st.title("Automation Plugins")
+    st.write("These plugins are available to the automation platform.")
+    render_plugin_list(automation_plugins, "No automation plugins available.")
+elif active_view == "Platforms":
+    st.title("Platforms")
+    render_platforms_panel(auto_connected)
+elif active_view == "Settings":
+    render_settings_page()


### PR DESCRIPTION
## Summary
- add sidebar navigation for chat, plugin catalogs, automation plugins, platforms, and settings
- show plugin cards with enable toggles, inline settings forms, and automation-only filtering powered by plugin_dec metadata
- provide clean plugin_name labels and user-friendly plugin_dec text across all plugins for clearer UI presentation
- update sidebar navigation to use full-width buttons and stack WebUI/Tater settings vertically for a tidier settings page
- sort plugin and automation plugin listings alphabetically for predictable browsing

## Testing
- python -m compileall webui.py plugins

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529a12a06c832abda93b00c38ae8f5)