### PR TITLE
Add Little Spud notification delivery

### DIFF
--- a/hydra/__init__.py
+++ b/hydra/__init__.py
@@ -667,6 +667,12 @@ _SEND_MESSAGE_PLATFORM_ALIASES: Dict[str, str] = {
     "macos": "macos",
     "mac os": "macos",
     "my mac": "macos",
+    "little_spud": "little_spud",
+    "little spud": "little_spud",
+    "little-spud": "little_spud",
+    "little_spuds": "little_spud",
+    "little spuds": "little_spud",
+    "little-spuds": "little_spud",
 }
 
 

--- a/hydra/hydra_toolcall_utils.py
+++ b/hydra/hydra_toolcall_utils.py
@@ -94,6 +94,12 @@ _SEND_MESSAGE_PLATFORM_ALIASES = {
     "mac-os": "macos",
     "mac_os": "macos",
     "my mac": "macos",
+    "little spud": "little_spud",
+    "little-spud": "little_spud",
+    "little_spud": "little_spud",
+    "little spuds": "little_spud",
+    "little-spuds": "little_spud",
+    "little_spuds": "little_spud",
 }
 
 

--- a/kernel_tools.py
+++ b/kernel_tools.py
@@ -1188,7 +1188,7 @@ def _send_message_extract_target_hint(raw: Any) -> str:
             return match.group(0)
     text = re.sub(r"^(?:room|channel|chat)\s+", "", text, flags=re.IGNORECASE)
     text = re.sub(
-        r"\s+(?:to|in|on)\s+(?:discord|irc|matrix|telegram|meshtastic|mesh|home\s*assistant|homeassistant|ntfy|web\s*ui|webui)\b.*$",
+        r"\s+(?:to|in|on)\s+(?:discord|irc|matrix|telegram|meshtastic|mesh|home\s*assistant|homeassistant|ntfy|web\s*ui|webui|little\s*spuds?|little[_-]spuds?)\b.*$",
         "",
         text,
         flags=re.IGNORECASE,
@@ -1971,7 +1971,7 @@ def send_message(
             code="missing_destination_platform",
             message="Cannot queue: missing destination platform",
             needs=[
-                "Specify a destination platform such as discord, matrix, telegram, meshtastic, macos, homeassistant, ntfy, irc, or webui.",
+                "Specify a destination platform such as discord, matrix, telegram, meshtastic, macos, little_spud, homeassistant, ntfy, irc, or webui.",
                 "For macOS you can also say 'my mac' or 'mac os'.",
             ],
             say_hint="Explain that a destination platform is required.",

--- a/notify/core.py
+++ b/notify/core.py
@@ -35,12 +35,13 @@ ALWAYS_ON_NOTIFIERS: Tuple[str, ...] = (
     "telegram",
     "meshtastic",
     "macos",
+    "little_spud",
     "webui",
     "display",
     "wordpress",
 )
 
-_ATTACHMENT_PLATFORMS = {"discord", "matrix", "telegram", "macos"}
+_ATTACHMENT_PLATFORMS = {"discord", "matrix", "telegram", "macos", "little_spud"}
 
 _URL_PATTERN = re.compile(r"https?://\S+")
 _BARE_URL_PATTERN = re.compile(r"(?<!\()(?<!\])\bhttps?://\S+\b")
@@ -825,7 +826,7 @@ def dispatch_notification_sync(
     if dest not in ALWAYS_ON_NOTIFIERS:
         return "Cannot queue: missing destination platform"
 
-    if dest in ("discord", "irc", "matrix", "telegram", "macos"):
+    if dest in ("discord", "irc", "matrix", "telegram", "macos", "little_spud"):
         return _enqueue_queue_notification(dest, title, content, targets, origin, meta, attachments=attachments)
 
     if dest == "webui":

--- a/notify/destinations.py
+++ b/notify/destinations.py
@@ -12,6 +12,7 @@ _PLATFORM_ORDER: Tuple[str, ...] = (
     "telegram",
     "meshtastic",
     "macos",
+    "little_spud",
     "homeassistant",
     "ntfy",
     "webui",
@@ -50,6 +51,11 @@ _PLATFORM_META: Dict[str, Dict[str, Any]] = {
         "requires_target": True,
         "fields": ("scope", "device_id"),
     },
+    "little_spud": {
+        "label": "Little Spud",
+        "requires_target": True,
+        "fields": ("node_id", "scope", "device_id", "user", "device_name"),
+    },
     "homeassistant": {
         "label": "Home Assistant",
         "requires_target": False,
@@ -82,6 +88,7 @@ _MAX_RECENT_KEYS = 160
 _ROOM_LABEL_PREFIX = "tater:room_label"
 _ROOM_META_PREFIX = "tater:room_meta"
 _SOURCE_PRIORITY: Dict[str, int] = {
+    "spud_link": 9,
     "room_label": 8,
     "recent_history": 7,
     "default": 6,
@@ -184,6 +191,13 @@ def _candidate_identity_key(platform: str, targets: Dict[str, str]) -> str:
         destination = _to_text(targets.get("destination") or targets.get("node_id") or "broadcast")
         channel = _to_text(targets.get("channel") or "0")
         return f"meshtastic:{channel}:{destination}"
+    if platform == "little_spud":
+        node_id = _to_text(targets.get("node_id"))
+        if node_id:
+            return f"little_spud:node_id:{node_id}"
+        scope = _to_text(targets.get("scope"))
+        if scope:
+            return f"little_spud:scope:{scope}"
     return _targets_key(targets)
 
 
@@ -253,6 +267,16 @@ def _platform_target_label(platform: str, targets: Dict[str, str]) -> str:
         if scope and device:
             return f"{scope} • {device}"
         return scope or device or "macOS target"
+    if platform == "little_spud":
+        user = _to_text(targets.get("user"))
+        device_name = _to_text(targets.get("device_name"))
+        device_id = _to_text(targets.get("device_id"))
+        node_id = _to_text(targets.get("node_id"))
+        if user and device_name:
+            return f"{user} on {device_name}"
+        if user and device_id:
+            return f"{user} on {device_id}"
+        return device_name or device_id or node_id or _to_text(targets.get("scope")) or "Little Spud"
     if platform == "homeassistant":
         target = _to_text(targets.get("device_service"))
         return target or "Home Assistant defaults"
@@ -429,6 +453,60 @@ def _default_targets_for_platform(platform: str, redis_client: Any) -> Dict[str,
     return defaults
 
 
+def _little_spud_targets_from_nodes(redis_client: Any, *, max_items: int) -> List[Dict[str, str]]:
+    if redis_client is None:
+        return []
+    try:
+        raw_nodes = redis_client.hgetall("tater:spudlink:nodes:v1") or {}
+    except Exception:
+        return []
+
+    rows: List[Dict[str, Any]] = []
+    for node_id, raw_value in raw_nodes.items():
+        text = _to_text(raw_value)
+        if not text:
+            continue
+        try:
+            node = json.loads(text)
+        except Exception:
+            continue
+        if not isinstance(node, dict):
+            continue
+        role = _to_text(node.get("role")).lower().replace("-", "_").replace(" ", "_")
+        if role != "little_spud":
+            continue
+        metadata = node.get("metadata") if isinstance(node.get("metadata"), dict) else {}
+        user_name = _to_text(metadata.get("user_name") or metadata.get("username") or node.get("user_name"))
+        device_name = _to_text(metadata.get("device_name") or metadata.get("device") or node.get("device_name"))
+        name = _to_text(node.get("name"))
+        if (not user_name or not device_name) and " on " in name:
+            left, right = name.split(" on ", 1)
+            user_name = user_name or _to_text(left)
+            device_name = device_name or _to_text(right)
+        resolved_node_id = _to_text(node.get("id") or node_id)
+        targets: Dict[str, str] = {}
+        if resolved_node_id:
+            targets["node_id"] = resolved_node_id
+        if user_name:
+            targets["user"] = user_name
+        if device_name:
+            targets["device_name"] = device_name
+            targets["device_id"] = device_name
+        if user_name or device_name:
+            targets["scope"] = f"user:{user_name or 'User'}:{device_name or 'Little Spud'}"
+        if targets:
+            rows.append(
+                {
+                    "targets": targets,
+                    "last_seen_at": float(node.get("last_seen_at") or node.get("created_at") or 0),
+                    "label": name,
+                }
+            )
+
+    rows.sort(key=lambda item: (-float(item.get("last_seen_at") or 0), _to_text(item.get("label")).lower()))
+    return [dict(item.get("targets") or {}) for item in rows[: max(1, min(500, int(max_items)))]]
+
+
 def _recent_queue_targets_for_platform(platform: str, redis_client: Any, *, max_items: int) -> List[Dict[str, str]]:
     key = queue_key(platform)
     if not key or redis_client is None:
@@ -602,6 +680,19 @@ def _platform_entry(
             if len(out_rows) >= int(limit):
                 break
 
+    if platform == "little_spud" and len(out_rows) < int(limit):
+        for targets in _little_spud_targets_from_nodes(redis_client, max_items=limit):
+            _append_candidate(
+                platform=platform,
+                targets=targets,
+                source="spud_link",
+                out=out_rows,
+                seen=seen,
+            )
+            source_tokens.add("spud_link")
+            if len(out_rows) >= int(limit):
+                break
+
     if len(out_rows) < int(limit):
         for targets in _room_label_targets_for_platform(platform, redis_client):
             _append_candidate(
@@ -616,7 +707,7 @@ def _platform_entry(
                 break
 
     discovery_sources = sorted(token for token in source_tokens if token)
-    supports_live_discovery = bool({"recent_queue", "recent_history"} & set(discovery_sources))
+    supports_live_discovery = bool({"recent_queue", "recent_history", "spud_link"} & set(discovery_sources))
     destination_groups: List[Dict[str, Any]] = []
     if platform == "discord":
         destination_groups = _discord_destination_groups(out_rows[: int(limit)])

--- a/notify/queue.py
+++ b/notify/queue.py
@@ -12,6 +12,7 @@ ALLOWED_PLATFORMS = (
     "telegram",
     "meshtastic",
     "macos",
+    "little_spud",
     "webui",
     "display",
 )
@@ -25,6 +26,7 @@ QUEUE_KEYS = {
     "telegram": "notifyq:telegram",
     "meshtastic": "notifyq:meshtastic",
     "macos": "notifyq:macos",
+    "little_spud": "notifyq:little_spud",
 }
 
 _DEFAULT_SETTINGS = {
@@ -81,6 +83,15 @@ _PLATFORM_ALIASES = {
     "current macs": "macos",
     "mac": "macos",
     "macs": "macos",
+    "little spud": "little_spud",
+    "little-spud": "little_spud",
+    "little_spud": "little_spud",
+    "little spuds": "little_spud",
+    "little-spuds": "little_spud",
+    "little_spuds": "little_spud",
+    "spud": "little_spud",
+    "spuds": "little_spud",
+    "pocket tater": "little_spud",
     "web ui": "webui",
     "web-ui": "webui",
     "web_ui": "webui",
@@ -305,6 +316,25 @@ def resolve_targets(
 
         if not (resolved.get("scope") or resolved.get("device_id")):
             return None, "Cannot queue: missing target device/scope"
+
+    elif platform == "little_spud":
+        if not resolved.get("node_id"):
+            if origin.get("platform") == "little_spud" and origin.get("node_id"):
+                resolved["node_id"] = origin.get("node_id")
+
+        if not resolved.get("scope"):
+            if origin.get("platform") == "little_spud":
+                if origin.get("scope"):
+                    resolved["scope"] = origin.get("scope")
+                elif origin.get("session_id"):
+                    resolved["scope"] = origin.get("session_id")
+
+        if not resolved.get("device_id"):
+            if origin.get("platform") == "little_spud" and origin.get("device_id"):
+                resolved["device_id"] = origin.get("device_id")
+
+        if not (resolved.get("node_id") or resolved.get("scope") or resolved.get("device_id")):
+            return None, "Cannot queue: missing target Little Spud"
 
     elif platform == "homeassistant":
         # No required target for persistent notifications

--- a/redis_runtime.py
+++ b/redis_runtime.py
@@ -1806,6 +1806,18 @@ class EncryptedRedisClientFacade:
             return rows
         return [self._decode(value) for value in rows]
 
+    def lrem(self, name: Any, count: int, value: Any):
+        removed = self._client.lrem(name, count, self._encode(value, name))
+        if int(removed or 0) > 0 or not self._should_encrypt(name):
+            return removed
+        rows = self._client.lrange(name, 0, -1) or []
+        target = _value_bytes(value)
+        for raw_value in rows:
+            if self._decoded_identity_bytes(raw_value) != target:
+                continue
+            return self._client.lrem(name, count, raw_value)
+        return removed
+
     def rpop(self, name: Any, count: Any = None):
         if count is None:
             return self._decode(self._client.rpop(name))

--- a/tateros_app.py
+++ b/tateros_app.py
@@ -67,6 +67,8 @@ from hydra import (
 )
 from emoji_responder import get_emoji_settings as get_core_emoji_settings, save_emoji_settings as save_core_emoji_settings
 from notify import notifier_destination_catalog
+from notify.media import BLOB_PREFIX as NOTIFY_BLOB_PREFIX, load_queue_attachments
+from notify.queue import is_expired as is_notify_expired, queue_key as notify_queue_key
 from helpers import (
     DEFAULT_HF_TRANSFORMERS_ATTN_IMPLEMENTATION,
     DEFAULT_HF_TRANSFORMERS_CONTEXT_TOKENS,
@@ -5348,6 +5350,130 @@ def _clear_little_spud_active_run(identity: Dict[str, str], run_id: str = "") ->
         pass
 
 
+def _little_spud_notification_target_matches(
+    *,
+    targets: Dict[str, Any],
+    identity: Dict[str, str],
+    node: Dict[str, Any],
+) -> bool:
+    target_map = targets if isinstance(targets, dict) else {}
+    wildcard_tokens = {"*", "all", "any"}
+    checks = (
+        ("node_id", str(node.get("id") or "").strip()),
+        ("scope", str(identity.get("scope") or "").strip()),
+        ("device_id", str(identity.get("device_name") or "").strip()),
+        ("device_name", str(identity.get("device_name") or "").strip()),
+        ("user", str(identity.get("user_name") or "").strip()),
+        ("user_name", str(identity.get("user_name") or "").strip()),
+    )
+    for key, expected in checks:
+        wanted = str(target_map.get(key) or "").strip()
+        if not wanted:
+            continue
+        if wanted.lower() in wildcard_tokens:
+            return True
+        return bool(expected and hmac.compare_digest(wanted, expected))
+    return False
+
+
+def _little_spud_notification_media_url(blob_key: str, mimetype: str) -> str:
+    ref = _b64url_encode(str(blob_key or "").encode("utf-8", errors="ignore"))
+    if not ref:
+        return ""
+    query = urlencode({"mimetype": str(mimetype or "application/octet-stream").strip() or "application/octet-stream"})
+    return f"/api/spudlink/v1/notification-media/{quote(ref)}?{query}"
+
+
+def _little_spud_notification_attachments(item_id: Any) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for item in load_queue_attachments(redis_client, item_id):
+        if not isinstance(item, dict):
+            continue
+        blob_key = str(item.get("blob_key") or "").strip()
+        if not blob_key:
+            continue
+        mimetype = str(item.get("mimetype") or "application/octet-stream").strip() or "application/octet-stream"
+        url = _little_spud_notification_media_url(blob_key, mimetype)
+        if not url:
+            continue
+        try:
+            size = int(item.get("size") or 0)
+        except Exception:
+            size = 0
+        out.append(
+            {
+                "id": str(item.get("id") or blob_key.rsplit(":", 1)[-1] or "").strip(),
+                "name": str(item.get("name") or "attachment").strip() or "attachment",
+                "type": str(item.get("type") or _media_type_from_mimetype(mimetype)),
+                "mimetype": mimetype,
+                "size": size,
+                "url": url,
+                "preview_url": url,
+            }
+        )
+    return out
+
+
+def _little_spud_notification_payload(item: Dict[str, Any]) -> Dict[str, Any]:
+    meta = item.get("meta") if isinstance(item.get("meta"), dict) else {}
+    origin = item.get("origin") if isinstance(item.get("origin"), dict) else {}
+    title = str(item.get("title") or "").strip()
+    message = str(item.get("message") or "").strip()
+    return {
+        "id": str(item.get("id") or f"lsnotify_{uuid.uuid4().hex[:16]}"),
+        "kind": "notification",
+        "title": title,
+        "message": message,
+        "content": message,
+        "created_at": float(item.get("created_at") or time.time()),
+        "createdAt": int(float(item.get("created_at") or time.time()) * 1000),
+        "priority": str(meta.get("priority") or "normal"),
+        "tags": list(meta.get("tags") or []) if isinstance(meta.get("tags"), list) else [],
+        "origin": origin,
+        "meta": meta,
+        "attachments": _little_spud_notification_attachments(item.get("id")),
+    }
+
+
+def _pop_little_spud_notification(
+    *,
+    identity: Dict[str, str],
+    node: Dict[str, Any],
+    wait_seconds: int,
+    max_scan: int = 200,
+) -> Optional[Dict[str, Any]]:
+    key = notify_queue_key("little_spud") or "notifyq:little_spud"
+    deadline = time.monotonic() + max(0.0, min(25.0, float(wait_seconds or 0)))
+    scan_count = max(1, min(500, int(max_scan or 200)))
+    while True:
+        try:
+            raw_rows = redis_client.lrange(key, 0, scan_count - 1) or []
+        except Exception:
+            raw_rows = []
+        for raw in raw_rows:
+            try:
+                item = json.loads(str(raw or "{}"))
+            except Exception:
+                redis_client.lrem(key, 1, raw)
+                continue
+            if not isinstance(item, dict):
+                redis_client.lrem(key, 1, raw)
+                continue
+            if is_notify_expired(item):
+                redis_client.lrem(key, 1, raw)
+                continue
+            targets = item.get("targets") if isinstance(item.get("targets"), dict) else {}
+            if not _little_spud_notification_target_matches(targets=targets, identity=identity, node=node):
+                continue
+            removed = int(redis_client.lrem(key, 1, raw) or 0)
+            if removed > 0:
+                return item
+
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(0.5)
+
+
 def _spud_link_public_settings_payload() -> Dict[str, Any]:
     settings = _load_spud_link_settings(include_secret=False)
     server_mode = _normalize_spud_link_tater_mode(settings.get("mode"))
@@ -5388,6 +5514,7 @@ def _spud_link_public_settings_payload() -> Dict[str, Any]:
             "llm": is_server,
             "hydra": is_server,
             "tools": little_spud_tools_enabled,
+            "notifications": is_server,
             "little_spud_clients": is_server and bool(settings.get("allow_little_spuds")),
             "spudlet_clients": is_server and bool(settings.get("allow_spudlets")),
         },
@@ -12303,6 +12430,7 @@ def pair_spud_link_node(payload: SpudLinkPairRequest, request: Request) -> Dict[
             "llm": is_server,
             "hydra": is_server,
             "tools": hydra_tools_enabled,
+            "notifications": is_server,
         },
     }
     return {
@@ -12435,6 +12563,7 @@ def spud_link_heartbeat(payload: SpudLinkHeartbeatRequest, request: Request) -> 
             "llm": is_server,
             "hydra": is_server,
             "tools": hydra_tools_enabled,
+            "notifications": is_server,
         },
     }
     return {
@@ -12475,6 +12604,65 @@ def spud_link_history(request: Request, limit: int = 80) -> Dict[str, Any]:
             "scope": identity.get("scope"),
         },
     }
+
+
+@app.get("/api/spudlink/v1/notifications/next")
+def spud_link_notification_next(request: Request, wait_seconds: int = 20) -> Dict[str, Any]:
+    _settings, node = _require_spud_link_node_request(request)
+    role = _normalize_spud_link_mode(node.get("role"), default=SPUD_LINK_MODE_SPUDLET)
+    if role != SPUD_LINK_MODE_LITTLE_SPUD:
+        raise HTTPException(status_code=403, detail="Little Spud notifications require a paired Little Spud client.")
+    identity_payload = type(
+        "SpudLinkNotificationIdentityPayload",
+        (),
+        {
+            "metadata": {},
+            "user_name": request.headers.get("x-spudlink-user"),
+            "device_name": request.headers.get("x-spudlink-device"),
+            "user": request.headers.get("x-spudlink-user"),
+        },
+    )()
+    identity = _spud_link_identity_from_request(identity_payload, request, node)
+    notification = _pop_little_spud_notification(
+        identity=identity,
+        node=node,
+        wait_seconds=max(0, min(25, int(wait_seconds or 0))),
+    )
+    _spud_link_touch_node_from_request(node, request)
+    _spud_link_store_node(node)
+    return {
+        "ok": True,
+        "notification": _little_spud_notification_payload(notification) if isinstance(notification, dict) else None,
+        "identity": {
+            "user_name": identity.get("user_name"),
+            "device_name": identity.get("device_name"),
+            "scope": identity.get("scope"),
+        },
+        "server_time": time.time(),
+    }
+
+
+@app.get("/api/spudlink/v1/notification-media/{media_ref}")
+def spud_link_notification_media(media_ref: str, request: Request, mimetype: str = "application/octet-stream") -> Response:
+    _settings, node = _require_spud_link_node_request(request)
+    role = _normalize_spud_link_mode(node.get("role"), default=SPUD_LINK_MODE_SPUDLET)
+    if role != SPUD_LINK_MODE_LITTLE_SPUD:
+        raise HTTPException(status_code=403, detail="Little Spud notification media requires a paired Little Spud client.")
+    try:
+        blob_key = _b64url_decode(media_ref).decode("utf-8", errors="ignore").strip()
+    except Exception as exc:
+        raise HTTPException(status_code=404, detail="Notification media not found.") from exc
+    if not blob_key or not blob_key.startswith(NOTIFY_BLOB_PREFIX):
+        raise HTTPException(status_code=404, detail="Notification media not found.")
+    raw = redis_blob_client.get(blob_key)
+    if not isinstance(raw, (bytes, bytearray)):
+        raw = redis_blob_client.get(blob_key.encode("utf-8", errors="ignore"))
+    if not isinstance(raw, (bytes, bytearray)):
+        raise HTTPException(status_code=404, detail="Notification media not found.")
+    _spud_link_touch_node_from_request(node, request)
+    _spud_link_store_node(node)
+    media_type = str(mimetype or "application/octet-stream").strip() or "application/octet-stream"
+    return Response(content=bytes(raw), media_type=media_type, headers={"Cache-Control": "private, max-age=3600"})
 
 
 @app.get("/api/spudlink/v1/files/{file_id}")

--- a/tool_runtime.py
+++ b/tool_runtime.py
@@ -736,6 +736,8 @@ async def run_meta_tool(
             persistent=args.get("persistent"),
             api_notification=args.get("api_notification"),
             chat_id=args.get("chat_id"),
+            device_id=args.get("device_id"),
+            scope=args.get("scope"),
             node_id=args.get("node_id"),
             mesh_destination=args.get("mesh_destination") or args.get("destination"),
         )


### PR DESCRIPTION
## Summary

- Adds `little_spud` as an always-on notification destination alongside Discord, Matrix, macOS, web UI, and the other existing notifiers.
- Queues Little Spud notifications through `notifyq:little_spud`, including attachment support and destination discovery from paired Spud Link nodes.
- Adds Spud Link notification polling/media endpoints so Little Spud clients can fetch queued messages and attached media from the paired Tater Hub.
- Exposes Little Spud aliases in the assistant send-message tooling so requests can target Little Spuds naturally.

## Impact

Little Spud clients can now receive Tater notifications through the same notify pipeline as the other notifier platforms, without APNs or external push infrastructure.

## Validation

- `python3.11 -m py_compile notify/queue.py notify/core.py notify/destinations.py kernel_tools.py tool_runtime.py hydra/__init__.py hydra/hydra_toolcall_utils.py redis_runtime.py tateros_app.py`
- Rebased cleanly on current `origin/main` before pushing the PR branch.

## Notes

Untracked `agent_lab/matrix-store` runtime files were left out of this branch.