### PR TITLE
Release Tater v98 audio scenes and stereo pairs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .venv/
 
 agent_lab/logs/*.log
+agent_lab/ai_task/background_audio/
 agent_lab/matrix-store/*.db
 agent_lab/matrix-store/*.db-*
 agent_lab/matrix-store/*.sqlite*

--- a/announcement_targets.py
+++ b/announcement_targets.py
@@ -368,6 +368,59 @@ def get_voice_core_satellite_target_options(*, current_values: Any = None) -> Li
         seen.add(value)
         rows.append({"value": value, "label": _voice_core_satellite_label(label_row, selector)})
 
+    try:
+        from tater_voice import stereo_pairs
+
+        required_capabilities = {
+            "synchronized_media_sessions",
+            "stereo_channel_selection",
+            "media_playhead_telemetry",
+            "media_drift_correction",
+        }
+        for pair in stereo_pairs.list_pairs():
+            pair_selector = _text(pair.get("selector"))
+            left_selector = _text(pair.get("left_selector"))
+            right_selector = _text(pair.get("right_selector"))
+            if not pair_selector or not left_selector or not right_selector:
+                continue
+            member_rows = [connected_clients.get(left_selector), connected_clients.get(right_selector)]
+            ready = all(isinstance(member, dict) for member in member_rows)
+            if ready:
+                for member in member_rows:
+                    capabilities = (
+                        member.get("capabilities")
+                        if isinstance(member.get("capabilities"), dict)
+                        else {}
+                    )
+                    try:
+                        session_version = int(float(capabilities.get("audio_session_version") or 0))
+                    except Exception:
+                        session_version = 0
+                    if session_version < 2 or any(
+                        not bool(capabilities.get(capability))
+                        for capability in required_capabilities
+                    ):
+                        ready = False
+                        break
+            value = f"{VOICE_CORE_TARGET_PREFIX}{pair_selector}"
+            if value in seen:
+                continue
+            seen.add(value)
+            left_name = _text((connected_clients.get(left_selector) or {}).get("device_name")) or left_selector
+            right_name = _text((connected_clients.get(right_selector) or {}).get("device_name")) or right_selector
+            status = "ready" if ready else "offline or firmware update required"
+            rows.append(
+                {
+                    "value": value,
+                    "label": (
+                        f"Tater Stereo: {_text(pair.get('name')) or pair_selector} "
+                        f"({left_name} L + {right_name} R • {status})"
+                    ),
+                }
+            )
+    except Exception:
+        pass
+
     for value in normalize_announcement_targets(current_values):
         if not value.startswith(VOICE_CORE_TARGET_PREFIX) or value in seen:
             continue

--- a/macos/Tater/RELEASE_NOTES.md
+++ b/macos/Tater/RELEASE_NOTES.md
@@ -1,28 +1,46 @@
-# Tater v97.7
+# Tater v98
 
 ## What's Changed
 
-### Satellite-Owned Timers
+### AI Task Broadcast Delivery
 
-- Native satellites now own their timer state, countdowns, and alarms instead of relying on Tater to persist or restore them.
-- Added support for multiple concurrent named timers on each satellite.
-- Timer requests can start, list, cancel, snooze, or stop a timer by name, duration, or identifier.
-- Reconnecting a satellite no longer clears or rebuilds its local timers.
-- Tater queries live timer state from connected satellites only when it is needed.
+- AI Task now has first-class broadcast delivery, so users choose the destination while creating the task instead of adding “then broadcast this” to the prompt.
+- Scheduled tasks deliver the final prepared response directly without asking a second LLM to rewrite it.
+- Broadcast destinations can be everywhere, an individual native satellite, or a configured stereo pair.
+- Added four generated background-audio presets plus validated WAV, MP3, and FLAC uploads stored under Agent Lab.
+- Per-task controls cover background volume, TTS volume, ducking level, attack/release timing, and finish fade.
+- Updated AI Task Core to 1.2.0 and Broadcast Verba to 1.3.0 in Tater Shop.
 
-### S3 Box Display
+### Satellite Music Ducking and Audio Scenes
 
-- Added per-S3 Box screen-brightness controls.
-- Added optional scheduled night dimming with configurable dim and restore times and a separate night brightness.
-- Screen settings only appear for individual S3 Boxes and are not sent to LED-only satellites.
-- Tater synchronizes local time to the S3 Box so its dimming schedule can continue through temporary disconnects.
+- Audio ACE and other music playback now use persistent native media sessions.
+- Unrelated TTS plays as an overlay, ducks the active music, and restores the prior music level without restarting the track.
+- Voice replies still honor each satellite’s Reply Playback destination.
+- Added global satellite duck level, attack, and release controls under Speech settings.
+- AI Task audio scenes can loop a background beneath TTS and stop it automatically when the announcement finishes.
+- Older firmware falls back clearly instead of silently claiming audio-scene support.
 
-### Timer Verba
+### Synchronized Stereo Pairs
 
-- Updated the Timer Verba for satellite-owned, concurrent named timers.
-- Improved timer-name and duration parsing for requests such as “cancel the 10 minute timer” or “how much time is left on the pasta timer.”
-- Timer responses now distinguish missing, ambiguous, unavailable, and successfully completed operations.
+- Added Stereo Pairs under Voice → Satellites with left/right member selection.
+- A pair appears as one reusable destination throughout Tater, AI Task, Broadcast, and Audio ACE.
+- Both members prebuffer the same source and start from a shared synchronized timestamp.
+- Music uses true left/right routing while TTS remains centered across the pair.
+- Per-side level and delay calibration is preserved while playhead telemetry and bounded drift correction maintain alignment.
+- TTS ducks both speakers together and synchronized AI Task backgrounds stop when the TTS completes.
+
+### Tater Native Firmware 0.3.0
+
+- Supports Voice PE, Satellite1, ReSpeaker XVF3800, and S3 Box with one shared 0.3.0 release.
+- Adds persistent sessions, versioned audio scenes, scheduled overlays, stereo channel selection, clock synchronization, and drift correction.
+- Existing `play.url` replies are automatically promoted to ducking overlays while media is active.
+- Firmware update availability continues to come from the signed native release manifest.
+
+### Native Media URL Reliability
+
+- `VOICE_CORE_PUBLIC_BASE_URL` now applies consistently to native TTS, streamed Chatterbox TTS, music, and background-audio URLs.
+- Bare hosts, full HTTP(S) URLs, explicit ports, paths, and IPv6-style authorities are normalized without duplicated schemes or ports.
 
 ### Validation
 
-- Added regression coverage for timer routing, named timer parsing, S3-only screen controls, schedule normalization, and firmware time synchronization.
+- Added regression coverage for stereo-pair persistence and compatibility, synchronized start/overlay behavior, drift correction, persistent media sessions, audio-scene routing, background-asset security, and public media URLs.

--- a/macos/Tater/Resources/Info.plist
+++ b/macos/Tater/Resources/Info.plist
@@ -20,9 +20,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>97.7</string>
+  <string>98</string>
   <key>CFBundleVersion</key>
-  <string>125</string>
+  <string>126</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>

--- a/media_playback.py
+++ b/media_playback.py
@@ -86,6 +86,7 @@ def _voice_core_play_media_sync(
     audio_bytes: bytes | None = None,
     text: str = "",
     media_type: str = "audio/mpeg",
+    media_content_type: str = "music",
     filename: str = "media.mp3",
     timeout_s: float = DEFAULT_MEDIA_PLAY_TIMEOUT_SECONDS,
     respect_reply_playback: bool = False,
@@ -98,6 +99,8 @@ def _voice_core_play_media_sync(
         "source_url": _text(source_url),
         "text": _text(text),
         "media_type": _text(media_type) or "audio/mpeg",
+        "media_content_type": _text(media_content_type) or "music",
+        "playback_role": "media",
         "filename": Path(_text(filename) or "media.mp3").name,
         "timeout_s": _as_float(timeout_s, DEFAULT_MEDIA_PLAY_TIMEOUT_SECONDS, minimum=30.0),
         "respect_reply_playback": bool(respect_reply_playback),
@@ -107,6 +110,9 @@ def _voice_core_play_media_sync(
 
     sent_count = 0
     failures: List[str] = []
+    media_session_sent_count = 0
+    media_session_fallback_count = 0
+    media_session_warnings: List[str] = []
     base_url = _voice_core_base_url().rstrip("/")
     headers = _voice_core_auth_headers()
 
@@ -122,6 +128,18 @@ def _voice_core_play_media_sync(
             )
             if response.status_code < 400:
                 sent_count += 1
+                response_payload: Dict[str, Any] = {}
+                with contextlib.suppress(Exception):
+                    parsed = response.json()
+                    if isinstance(parsed, dict):
+                        response_payload = parsed
+                if bool(response_payload.get("media_session_started")):
+                    media_session_sent_count += 1
+                else:
+                    media_session_fallback_count += 1
+                    reason = _text(response_payload.get("media_session_fallback_reason"))
+                    if reason:
+                        media_session_warnings.append(f"{selector} ({reason})")
                 continue
             detail = ""
             with contextlib.suppress(Exception):
@@ -132,7 +150,14 @@ def _voice_core_play_media_sync(
             failures.append(f"{selector} ({exc})")
 
     if sent_count:
-        result: Dict[str, Any] = {"ok": True, "sent_count": sent_count}
+        result: Dict[str, Any] = {
+            "ok": True,
+            "sent_count": sent_count,
+            "media_session_sent_count": media_session_sent_count,
+            "media_session_fallback_count": media_session_fallback_count,
+        }
+        if media_session_warnings:
+            result["media_session_warnings"] = media_session_warnings
         if failures:
             result["warnings"] = failures
         return result
@@ -328,11 +353,19 @@ def play_media_url_targets(
             audio_bytes=bytes(audio_bytes or b"") if isinstance(audio_bytes, (bytes, bytearray)) else None,
             text=text,
             media_type=clean_media_type,
+            media_content_type=media_content_type,
             filename=safe_filename,
             timeout_s=timeout_s,
             respect_reply_playback=respect_reply_playback,
         )
         result["voice_core_sent_count"] = int(voice_result.get("sent_count") or 0)
+        result["media_session_sent_count"] = int(voice_result.get("media_session_sent_count") or 0)
+        result["media_session_fallback_count"] = int(voice_result.get("media_session_fallback_count") or 0)
+        result["media_session_warnings"] = [
+            _text(item)
+            for item in list(voice_result.get("media_session_warnings") or [])
+            if _text(item)
+        ]
         sent_count += int(voice_result.get("sent_count") or 0)
         warnings.extend([_text(item) for item in list(voice_result.get("warnings") or []) if _text(item)])
         if not voice_result.get("ok") and _text(voice_result.get("error")):

--- a/scripts/test_ai_task_audio_assets.py
+++ b/scripts/test_ai_task_audio_assets.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import ast
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+from fastapi import HTTPException
+from fastapi.responses import FileResponse
+
+
+def _load_audio_response_helper(root: Path):
+    source_path = Path(__file__).resolve().parents[1] / "tateros_app.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    selected = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_ai_task_background_audio_response"
+    ]
+    if len(selected) != 1:
+        raise RuntimeError("Missing AI Task background audio response helper.")
+
+    module = types.ModuleType("test_ai_task_audio_response")
+    module.__dict__.update(
+        {
+            "Path": Path,
+            "HTTPException": HTTPException,
+            "FileResponse": FileResponse,
+            "mimetypes": __import__("mimetypes"),
+            "agent_lab_path": lambda *parts: root.joinpath(*parts),
+        }
+    )
+    compiled = ast.Module(body=selected, type_ignores=[])
+    ast.fix_missing_locations(compiled)
+    exec(compile(compiled, str(source_path), "exec"), module.__dict__)
+    return module._ai_task_background_audio_response
+
+
+class AiTaskAudioAssetTests(unittest.TestCase):
+    def test_serves_only_supported_files_inside_agent_lab_audio_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            presets = root / "ai_task" / "background_audio" / "presets"
+            presets.mkdir(parents=True)
+            audio_path = presets / "morning.wav"
+            audio_path.write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
+            response_for = _load_audio_response_helper(root)
+
+            response = response_for("presets", "morning.wav")
+            self.assertIsInstance(response, FileResponse)
+            self.assertEqual(Path(response.path).resolve(), audio_path.resolve())
+            self.assertIn(response.media_type, {"audio/wav", "audio/x-wav"})
+
+            with self.assertRaises(HTTPException) as traversal:
+                response_for("presets", "../morning.wav")
+            self.assertEqual(traversal.exception.status_code, 404)
+
+            with self.assertRaises(HTTPException) as unsupported:
+                response_for("presets", "notes.txt")
+            self.assertEqual(unsupported.exception.status_code, 404)
+
+            with self.assertRaises(HTTPException) as unknown_kind:
+                response_for("private", "morning.wav")
+            self.assertEqual(unknown_kind.exception.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_media_playback_sessions.py
+++ b/scripts/test_media_playback_sessions.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import media_playback
+
+
+class _Response:
+    status_code = 200
+
+    @staticmethod
+    def json():
+        return {
+            "ok": True,
+            "media_session_started": True,
+        }
+
+
+class MediaPlaybackSessionTests(unittest.TestCase):
+    def test_voice_core_music_request_declares_persistent_media_role(self) -> None:
+        with (
+            mock.patch.object(media_playback, "_voice_core_base_url", return_value="http://127.0.0.1:8501"),
+            mock.patch.object(media_playback, "_voice_core_auth_headers", return_value={}),
+            mock.patch.object(media_playback.requests, "post", return_value=_Response()) as post,
+        ):
+            result = media_playback._voice_core_play_media_sync(
+                selectors=["native:kitchen"],
+                source_url="https://example.test/song.mp3",
+                media_type="audio/mpeg",
+                media_content_type="music",
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["media_session_sent_count"], 1)
+        payload = post.call_args.kwargs["json"]
+        self.assertEqual(payload["playback_role"], "media")
+        self.assertEqual(payload["media_content_type"], "music")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_native_audio_scene_route.py
+++ b/scripts/test_native_audio_scene_route.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+import base64
+import contextlib
+import sys
+import types
+import unittest
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class FakeHttpException(Exception):
+    def __init__(self, status_code: int, detail: str):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+class FakeReplyPlayback:
+    REPLY_PLAYBACK_DEVICE = "device"
+    REPLY_PLAYBACK_SILENT = "silent"
+
+    @staticmethod
+    def resolve_reply_playback_target(*_args, **_kwargs):
+        return "device"
+
+
+class FakeLogger:
+    def warning(self, *_args, **_kwargs):
+        return None
+
+
+class FakeVoicePipeline:
+    def __init__(self):
+        self.reply_playback = FakeReplyPlayback()
+        self.logger = FakeLogger()
+        self.stored = []
+
+    @staticmethod
+    def _require_api_auth(_token):
+        return None
+
+    @staticmethod
+    def _text(value):
+        return str(value or "").strip()
+
+    @staticmethod
+    def _as_bool(value, default=False):
+        if isinstance(value, bool):
+            return value
+        token = str(value or "").strip().lower()
+        if not token:
+            return bool(default)
+        return token in {"1", "true", "yes", "on", "enabled"}
+
+    @staticmethod
+    def _as_float(value, default=0.0):
+        try:
+            return float(value)
+        except Exception:
+            return float(default)
+
+    @staticmethod
+    def _satellite_lookup(_selector):
+        return {}
+
+    @staticmethod
+    def _esphome_client_row_snapshot_sync(_selector):
+        return {}
+
+    async def _download_media_source(self, source_url):
+        self.background_source_url = source_url
+        return b"background", "audio/mpeg"
+
+    def _store_media_url(self, selector, session_id, media_bytes, *, media_type, filename):
+        self.stored.append(
+            {
+                "selector": selector,
+                "session_id": session_id,
+                "bytes": media_bytes,
+                "media_type": media_type,
+                "filename": filename,
+            }
+        )
+        return (
+            "http://voice-core/media/background"
+            if filename == "background-audio"
+            else "http://voice-core/media/foreground"
+        )
+
+
+def _load_route_functions(fake_vp):
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "tater_voice"
+        / "voice_pipeline"
+        / "routes.py"
+    )
+    wanted = {
+        "_native_audio_scene_payload",
+        "_native_ducking_payload",
+        "native_satellite_play",
+    }
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    selected = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in wanted:
+            node.decorator_list = []
+            selected.append(node)
+    if len(selected) != len(wanted):
+        found = {node.name for node in selected}
+        raise RuntimeError(f"Missing route functions: {sorted(wanted - found)}")
+
+    module = types.ModuleType("tater_voice.voice_pipeline.scene_route_test")
+    module.__package__ = "tater_voice.voice_pipeline"
+    module.__dict__.update(
+        {
+            "Any": Any,
+            "Dict": Dict,
+            "Optional": Optional,
+            "HTTPException": FakeHttpException,
+            "Header": lambda default=None: default,
+            "base64": base64,
+            "contextlib": contextlib,
+            "uuid": __import__("uuid"),
+            "_vp": lambda: fake_vp,
+        }
+    )
+    compiled = ast.Module(body=selected, type_ignores=[])
+    ast.fix_missing_locations(compiled)
+    exec(compile(compiled, str(path), "exec"), module.__dict__)
+    return module
+
+
+def _load_capability_helpers():
+    path = Path(__file__).resolve().parents[1] / "tater_voice" / "native_satellite.py"
+    wanted = {"_text", "_lower", "_as_bool", "_capabilities"}
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    selected = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in wanted
+    ]
+    module = types.ModuleType("native_capability_test")
+    module.__dict__.update({"Any": Any, "Dict": Dict})
+    compiled = ast.Module(body=selected, type_ignores=[])
+    ast.fix_missing_locations(compiled)
+    exec(compile(compiled, str(path), "exec"), module.__dict__)
+    return module
+
+
+class NativeCapabilityTests(unittest.TestCase):
+    def test_preserves_audio_scene_version_and_normalizes_boolean_strings(self) -> None:
+        native = _load_capability_helpers()
+        capabilities = native._capabilities(
+            {
+                "capabilities": {
+                    "audio_scenes": "true",
+                    "audio_scene_version": 1,
+                    "audio_session_version": 1,
+                    "legacy_feature": "false",
+                }
+            }
+        )
+        self.assertIs(capabilities["audio_scenes"], True)
+        self.assertEqual(capabilities["audio_scene_version"], 1)
+        self.assertEqual(capabilities["audio_session_version"], 1)
+        self.assertIs(capabilities["legacy_feature"], False)
+
+
+class NativeAudioSceneRouteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.vp = FakeVoicePipeline()
+        self.commands = []
+        self.stereo_calls = []
+        self.stereo_pair = {}
+        self.scene_supported = True
+        self.media_session_active = False
+        self.capabilities = {
+            "audio_scenes": True,
+            "persistent_media_sessions": True,
+            "tts_overlays": True,
+        }
+
+        native = types.ModuleType("tater_voice.native_satellite")
+
+        async def client_has_capability(_selector, capability):
+            if capability == "audio_scenes":
+                return self.scene_supported
+            return bool(self.capabilities.get(capability))
+
+        async def client_media_session_active(_selector):
+            return self.media_session_active
+
+        async def send_command(selector, message_type, payload):
+            self.commands.append((selector, message_type, payload))
+            return {"queued": True}
+
+        async def prepare_stereo_media_session(pair, **kwargs):
+            self.stereo_calls.append(("media", pair, kwargs))
+            return {"stereo_session_started": True, "start_server_us": 123456789}
+
+        async def start_stereo_overlay(pair, **kwargs):
+            self.stereo_calls.append(("overlay", pair, kwargs))
+            return {"stereo_overlay_started": True}
+
+        native.client_has_capability = client_has_capability
+        native.client_media_session_active = client_media_session_active
+        native.send_command = send_command
+        native.prepare_stereo_media_session = prepare_stereo_media_session
+        native.start_stereo_overlay = start_stereo_overlay
+        native.stereo_pair_media_active = lambda _pair: self.media_session_active
+
+        stereo_pairs = types.ModuleType("tater_voice.stereo_pairs")
+        stereo_pairs.is_stereo_selector = lambda selector: str(selector or "").startswith("stereo:")
+        stereo_pairs.get_pair = lambda _selector: dict(self.stereo_pair)
+
+        self.previous_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "tater_voice",
+                "tater_voice.voice_pipeline",
+                "tater_voice.native_satellite",
+                "tater_voice.stereo_pairs",
+            )
+        }
+        package = types.ModuleType("tater_voice")
+        package.__path__ = []
+        voice_pipeline_package = types.ModuleType("tater_voice.voice_pipeline")
+        voice_pipeline_package.__path__ = []
+        package.native_satellite = native
+        package.stereo_pairs = stereo_pairs
+        sys.modules["tater_voice"] = package
+        sys.modules["tater_voice.voice_pipeline"] = voice_pipeline_package
+        sys.modules["tater_voice.native_satellite"] = native
+        sys.modules["tater_voice.stereo_pairs"] = stereo_pairs
+        self.routes = _load_route_functions(self.vp)
+
+    def tearDown(self) -> None:
+        for name, previous in self.previous_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+    @staticmethod
+    def _payload():
+        return {
+            "selector": "native:kitchen",
+            "audio_b64": base64.b64encode(b"foreground").decode("ascii"),
+            "media_type": "audio/wav",
+            "filename": "tts.wav",
+            "respect_reply_playback": False,
+            "audio_scene": {
+                "background": {
+                    "url": "https://example.test/morning.mp3",
+                    "loop": True,
+                    "volume_percent": 60,
+                },
+                "ducking": {
+                    "target_percent": 35,
+                    "attack_ms": 150,
+                    "release_ms": 350,
+                },
+                "finish": {"fade_ms": 500},
+            },
+        }
+
+    def test_supported_satellite_receives_audio_scene_command(self) -> None:
+        result = asyncio.run(self.routes.native_satellite_play(self._payload(), None))
+
+        self.assertTrue(result["audio_scene_started"])
+        self.assertEqual(self.commands[0][1], "audio.scene.start")
+        scene = self.commands[0][2]
+        self.assertEqual(scene["foreground"]["url"], "http://voice-core/media/foreground")
+        self.assertEqual(scene["background"]["url"], "http://voice-core/media/background")
+        self.assertEqual(scene["ducking"]["target_percent"], 35)
+        self.assertEqual(self.vp.background_source_url, "https://example.test/morning.mp3")
+
+    def test_older_satellite_falls_back_to_play_url(self) -> None:
+        self.scene_supported = False
+        result = asyncio.run(self.routes.native_satellite_play(self._payload(), None))
+
+        self.assertFalse(result["audio_scene_started"])
+        self.assertIn("does not advertise", result["audio_scene_fallback_reason"])
+        self.assertEqual(self.commands[0][1], "play.url")
+        self.assertEqual(len(self.vp.stored), 1)
+
+    def test_music_uses_persistent_media_session(self) -> None:
+        payload = {
+            "selector": "native:kitchen",
+            "audio_b64": base64.b64encode(b"music").decode("ascii"),
+            "media_type": "audio/mpeg",
+            "media_content_type": "music",
+            "playback_role": "media",
+            "filename": "song.mp3",
+            "respect_reply_playback": False,
+        }
+        result = asyncio.run(self.routes.native_satellite_play(payload, None))
+
+        self.assertTrue(result["media_session_started"])
+        self.assertEqual(self.commands[0][1], "media.session.start")
+        self.assertEqual(
+            self.commands[0][2]["media"]["url"],
+            "http://voice-core/media/foreground",
+        )
+
+    def test_tts_uses_overlay_when_media_session_is_active(self) -> None:
+        self.media_session_active = True
+        payload = {
+            "selector": "native:kitchen",
+            "audio_b64": base64.b64encode(b"speech").decode("ascii"),
+            "media_type": "audio/wav",
+            "filename": "tts.wav",
+            "respect_reply_playback": False,
+            "ducking": {
+                "target_percent": 28,
+                "attack_ms": 90,
+                "release_ms": 420,
+            },
+        }
+        result = asyncio.run(self.routes.native_satellite_play(payload, None))
+
+        self.assertTrue(result["audio_overlay_started"])
+        self.assertEqual(self.commands[0][1], "audio.overlay.start")
+        self.assertEqual(self.commands[0][2]["ducking"]["target_percent"], 28)
+
+    def test_stereo_pair_music_uses_synchronized_session(self) -> None:
+        self.stereo_pair = {
+            "id": "bedroom12",
+            "selector": "stereo:bedroom12",
+            "left_selector": "native:left",
+            "right_selector": "native:right",
+        }
+        payload = {
+            "selector": "stereo:bedroom12",
+            "audio_b64": base64.b64encode(b"stereo music").decode("ascii"),
+            "media_type": "audio/mpeg",
+            "media_content_type": "music",
+            "playback_role": "media",
+            "filename": "song.mp3",
+            "respect_reply_playback": False,
+        }
+
+        result = asyncio.run(self.routes.native_satellite_play(payload, None))
+
+        self.assertTrue(result["media_session_started"])
+        self.assertEqual(self.stereo_calls[0][0], "media")
+        self.assertEqual(self.stereo_calls[0][2]["channel_mode"], "stereo")
+        self.assertEqual(
+            self.stereo_calls[0][2]["media_url"],
+            "http://voice-core/media/foreground",
+        )
+
+    def test_stereo_pair_audio_scene_synchronizes_background_and_tts(self) -> None:
+        self.stereo_pair = {
+            "id": "bedroom12",
+            "selector": "stereo:bedroom12",
+            "left_selector": "native:left",
+            "right_selector": "native:right",
+        }
+        payload = self._payload()
+        payload["selector"] = "stereo:bedroom12"
+
+        result = asyncio.run(self.routes.native_satellite_play(payload, None))
+
+        self.assertTrue(result["audio_scene_started"])
+        self.assertTrue(result["media_session_started"])
+        self.assertTrue(result["audio_overlay_started"])
+        self.assertEqual([row[0] for row in self.stereo_calls], ["media", "overlay"])
+        background = self.stereo_calls[0][2]
+        overlay = self.stereo_calls[1][2]
+        self.assertEqual(background["media_url"], "http://voice-core/media/background")
+        self.assertTrue(background["loop"])
+        self.assertEqual(background["volume_percent"], 60)
+        self.assertEqual(overlay["foreground_url"], "http://voice-core/media/foreground")
+        self.assertEqual(overlay["ducking"]["target_percent"], 35)
+        self.assertEqual(overlay["start_server_us"], 123456789)
+        self.assertTrue(overlay["stop_media_when_finished"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_native_public_base_url.py
+++ b/scripts/test_native_public_base_url.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tater_voice import voice_pipeline as vp  # noqa: E402
+
+
+class NativePublicBaseUrlTests(unittest.TestCase):
+    def setUp(self) -> None:
+        with vp._tts_url_store_lock:
+            vp._tts_url_store.clear()
+
+    def tearDown(self) -> None:
+        with vp._tts_url_store_lock:
+            vp._tts_url_store.clear()
+
+    def test_public_base_url_takes_precedence_and_preserves_path(self) -> None:
+        env = {
+            "VOICE_CORE_PUBLIC_BASE_URL": "https://tater.example.com/tater/",
+            "VOICE_CORE_PUBLIC_HOST": "internal.example.com",
+            "HTMLUI_PORT": "8501",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            self.assertEqual(
+                vp._service_base_url_for_peer("192.168.1.50"),
+                "https://tater.example.com/tater",
+            )
+
+    def test_public_host_accepts_full_url_without_double_scheme(self) -> None:
+        env = {
+            "VOICE_CORE_PUBLIC_BASE_URL": "",
+            "VOICE_CORE_PUBLIC_HOST": "https://tater.example.com/",
+            "HTMLUI_PORT": "8501",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            self.assertEqual(
+                vp._service_base_url_for_peer("192.168.1.50"),
+                "https://tater.example.com",
+            )
+
+    def test_bare_public_host_uses_app_port_without_duplicating_explicit_port(self) -> None:
+        env = {
+            "VOICE_CORE_PUBLIC_BASE_URL": "",
+            "VOICE_CORE_PUBLIC_HOST": "tater.example.com",
+            "HTMLUI_PORT": "8501",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            self.assertEqual(
+                vp._service_base_url_for_peer("192.168.1.50"),
+                "http://tater.example.com:8501",
+            )
+
+        env["VOICE_CORE_PUBLIC_HOST"] = "tater.example.com:9443"
+        with mock.patch.dict(os.environ, env, clear=False):
+            self.assertEqual(
+                vp._service_base_url_for_peer("192.168.1.50"),
+                "http://tater.example.com:9443",
+            )
+
+    def test_native_playback_urls_share_public_base_url(self) -> None:
+        public_base_url = "https://tater.example.com/tater"
+        with (
+            mock.patch.object(vp, "_service_base_url_for_peer", return_value=public_base_url),
+            mock.patch.object(
+                vp,
+                "_pcm_to_wav",
+                return_value=(b"wav", {"rate": 16000, "width": 2, "channels": 1}),
+            ),
+            mock.patch.object(
+                vp,
+                "_chatterbox_tts_request",
+                return_value=("http://chatterbox/tts", {"text": "hello"}),
+            ),
+            mock.patch.object(vp, "_tts_url_ttl_s", return_value=180.0),
+        ):
+            tts_url = vp._store_tts_url(
+                "native:test",
+                "session",
+                b"pcm",
+                {"rate": 16000, "width": 2, "channels": 1},
+            )
+            chatterbox_url = vp._store_chatterbox_tts_stream_url(
+                "native:test",
+                "session",
+                "hello",
+                {},
+            )
+            media_url = vp._store_media_url(
+                "native:test",
+                "session",
+                b"media",
+                media_type="audio/mpeg",
+                filename="music.mp3",
+            )
+
+        self.assertRegex(
+            tts_url,
+            r"^https://tater\.example\.com/tater/api/tater/satellite/v1/tts/[0-9a-f]+\.wav$",
+        )
+        self.assertRegex(
+            chatterbox_url,
+            r"^https://tater\.example\.com/tater/api/tater/satellite/v1/tts/[0-9a-f]+\.wav$",
+        )
+        self.assertRegex(
+            media_url,
+            r"^https://tater\.example\.com/tater/api/tater/satellite/v1/media/[0-9a-f]+$",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_stereo_pairs.py
+++ b/scripts/test_stereo_pairs.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import announcement_targets
+from tater_voice import native_satellite, stereo_pairs
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.values = {}
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value):
+        self.values[key] = value
+        return True
+
+
+class StereoPairPersistenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.redis = _FakeRedis()
+        self.redis_patch = mock.patch.object(stereo_pairs, "redis_client", self.redis)
+        self.redis_patch.start()
+
+    def tearDown(self) -> None:
+        self.redis_patch.stop()
+
+    def test_pair_round_trip_and_member_exclusivity(self) -> None:
+        saved = stereo_pairs.save_pair(
+            {
+                "name": "Bedroom Stereo",
+                "left_selector": "native:left",
+                "right_selector": "native:right",
+                "left_delay_ms": 4,
+                "right_volume_percent": 92,
+            }
+        )
+        self.assertTrue(saved["selector"].startswith("stereo:"))
+        loaded = stereo_pairs.get_pair(saved["selector"])
+        self.assertEqual(loaded["left_selector"], "native:left")
+        self.assertEqual(loaded["left_delay_ms"], 4)
+        self.assertEqual(loaded["right_volume_percent"], 92)
+
+        with self.assertRaisesRegex(ValueError, "already assigned"):
+            stereo_pairs.save_pair(
+                {
+                    "name": "Conflicting Pair",
+                    "left_selector": "native:left",
+                    "right_selector": "native:other",
+                }
+            )
+
+        removed = stereo_pairs.remove_pair(saved["selector"])
+        self.assertTrue(removed["removed"])
+        self.assertEqual(stereo_pairs.list_pairs(), [])
+        document = json.loads(self.redis.values[stereo_pairs.REDIS_STEREO_PAIRS_KEY])
+        self.assertEqual(document["version"], 1)
+
+    def test_ready_pair_appears_as_one_announcement_destination(self) -> None:
+        saved = stereo_pairs.save_pair(
+            {
+                "name": "Office Stereo",
+                "left_selector": "native:left",
+                "right_selector": "native:right",
+            }
+        )
+        capabilities = {
+            "audio_session_version": 2,
+            "synchronized_media_sessions": True,
+            "stereo_channel_selection": True,
+            "media_playhead_telemetry": True,
+            "media_drift_correction": True,
+        }
+        connected = {
+            "native:left": {
+                "connected": True,
+                "device_name": "Office Left",
+                "capabilities": capabilities,
+            },
+            "native:right": {
+                "connected": True,
+                "device_name": "Office Right",
+                "capabilities": capabilities,
+            },
+        }
+        self.redis.values[announcement_targets.REDIS_VOICE_SATELLITE_REGISTRY_KEY] = "[]"
+        with (
+            mock.patch.object(announcement_targets, "_voice_core_connected_clients", return_value=connected),
+            mock.patch.object(announcement_targets, "redis_client", self.redis),
+        ):
+            options = announcement_targets.get_voice_core_satellite_target_options()
+
+        pair_value = f"voice_core:{saved['selector']}"
+        pair_option = next(row for row in options if row["value"] == pair_value)
+        self.assertIn("Tater Stereo: Office Stereo", pair_option["label"])
+        self.assertIn("ready", pair_option["label"])
+
+
+class StereoCoordinatorTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        native_satellite._stereo_sessions.clear()
+        for task in list(native_satellite._stereo_adjust_tasks.values()):
+            task.cancel()
+        native_satellite._stereo_adjust_tasks.clear()
+
+    async def asyncTearDown(self) -> None:
+        for task in list(native_satellite._stereo_adjust_tasks.values()):
+            task.cancel()
+        native_satellite._stereo_adjust_tasks.clear()
+        native_satellite._stereo_sessions.clear()
+
+    async def test_prepare_waits_for_both_then_commits_shared_start(self) -> None:
+        calls = []
+
+        async def fake_request(selector, message_type, payload, *, timeout_s=3.0):
+            calls.append((selector, message_type, dict(payload), timeout_s))
+            return {"ok": True}
+
+        async def fake_clock(selector):
+            return {
+                "selector": selector,
+                "offset_us": 1000 if selector.endswith("left") else 2000,
+                "round_trip_us": 500,
+            }
+
+        pair = {
+            "id": "bedroom12",
+            "selector": "stereo:bedroom12",
+            "left_selector": "native:left",
+            "right_selector": "native:right",
+            "left_volume_percent": 100,
+            "right_volume_percent": 90,
+            "left_delay_ms": 0,
+            "right_delay_ms": 3,
+        }
+        with (
+            mock.patch.object(
+                native_satellite,
+                "stereo_pair_compatibility",
+                mock.AsyncMock(return_value={"ok": True}),
+            ),
+            mock.patch.object(native_satellite, "_stereo_clock_probe", side_effect=fake_clock),
+            mock.patch.object(native_satellite, "send_request", side_effect=fake_request),
+        ):
+            result = await native_satellite.prepare_stereo_media_session(
+                pair,
+                session_id="session-1",
+                media_url="http://tater/media/song",
+                volume_percent=80,
+                loop=True,
+            )
+
+        self.assertTrue(result["stereo_session_started"])
+        prepare_calls = [row for row in calls if row[1] == "media.session.prepare"]
+        commit_calls = [row for row in calls if row[1] == "media.session.commit"]
+        self.assertEqual(len(prepare_calls), 2)
+        self.assertEqual(len(commit_calls), 2)
+        self.assertEqual(prepare_calls[0][2]["routing"]["channel"], "left")
+        self.assertEqual(prepare_calls[1][2]["routing"]["channel"], "right")
+        self.assertEqual(prepare_calls[1][2]["media"]["volume_percent"], 72)
+        left_start = commit_calls[0][2]["start_at_us"]
+        right_start = commit_calls[1][2]["start_at_us"]
+        self.assertEqual(right_start - left_start, 4000)
+        self.assertIn("bedroom12", native_satellite._stereo_sessions)
+
+    async def test_phase_error_adjusts_right_member_toward_left(self) -> None:
+        now_us = native_satellite._monotonic_us()
+        native_satellite._stereo_sessions["pair1"] = {
+            "group_id": "pair1",
+            "session_id": "session-1",
+            "left_selector": "native:left",
+            "right_selector": "native:right",
+            "clock_offsets_us": {"native:left": 0, "native:right": 0},
+            "clock_sync_server_us": now_us,
+            "last_adjust_server_us": 0,
+            "playheads": {
+                "native:left": {
+                    "session_id": "session-1",
+                    "source_frames": 48048,
+                    "sample_rate_hz": 48000,
+                    "satellite_time_us": now_us,
+                },
+                "native:right": {
+                    "session_id": "session-1",
+                    "source_frames": 48000,
+                    "sample_rate_hz": 48000,
+                    "satellite_time_us": now_us,
+                },
+            },
+        }
+        sent = []
+
+        async def fake_request(selector, message_type, payload, *, timeout_s=3.0):
+            sent.append((selector, message_type, dict(payload), timeout_s))
+            return {"ok": True}
+
+        with mock.patch.object(native_satellite, "send_request", side_effect=fake_request):
+            await native_satellite._adjust_stereo_session("pair1")
+
+        self.assertEqual(sent[0][0], "native:right")
+        self.assertEqual(sent[0][1], "media.session.adjust")
+        self.assertEqual(sent[0][2]["correction_frames"], 48)
+
+    async def test_scheduled_overlay_uses_pair_calibration_and_stops_scene_media(self) -> None:
+        now_us = native_satellite._monotonic_us()
+        native_satellite._stereo_sessions["pair1"] = {
+            "group_id": "pair1",
+            "pair_selector": "stereo:pair1",
+            "session_id": "background-1",
+            "left_selector": "native:left",
+            "right_selector": "native:right",
+            "clock_offsets_us": {"native:left": 1000, "native:right": 2000},
+        }
+        pair = {
+            "id": "pair1",
+            "selector": "stereo:pair1",
+            "left_selector": "native:left",
+            "right_selector": "native:right",
+            "left_delay_ms": 0,
+            "right_delay_ms": 3,
+            "left_volume_percent": 100,
+            "right_volume_percent": 80,
+        }
+        sent = []
+
+        async def fake_command(selector, message_type, payload):
+            sent.append((selector, message_type, dict(payload)))
+            return {"ok": True}
+
+        with (
+            mock.patch.object(
+                native_satellite,
+                "stereo_pair_compatibility",
+                mock.AsyncMock(return_value={"ok": True}),
+            ),
+            mock.patch.object(native_satellite, "send_command", side_effect=fake_command),
+            mock.patch.object(native_satellite, "_stop_stereo_members", mock.AsyncMock()) as stop_mock,
+        ):
+            result = await native_satellite.start_stereo_overlay(
+                pair,
+                overlay_id="overlay-1",
+                foreground_url="http://tater/media/tts",
+                foreground_volume_percent=90,
+                start_server_us=now_us + 500_000,
+                stop_media_when_finished=True,
+            )
+            self.assertTrue(result["stop_media_when_finished"])
+            self.assertEqual(len(sent), 2)
+            self.assertEqual(
+                sent[1][2]["start_at_us"] - sent[0][2]["start_at_us"],
+                4000,
+            )
+            self.assertEqual(sent[1][2]["foreground"]["volume_percent"], 72)
+
+            native_satellite._record_stereo_overlay_finished(
+                "native:left",
+                {"overlay_id": "overlay-1", "ok": True},
+            )
+            await asyncio.sleep(0)
+            stop_mock.assert_not_awaited()
+            native_satellite._record_stereo_overlay_finished(
+                "native:right",
+                {"overlay_id": "overlay-1", "ok": True},
+            )
+            await asyncio.sleep(0)
+            stop_mock.assert_awaited_once_with(
+                ["native:left", "native:right"],
+                session_id="background-1",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/speech_settings.py
+++ b/speech_settings.py
@@ -37,6 +37,9 @@ DEFAULT_POCKET_TTS_VOICE = "alba"
 DEFAULT_POCKET_TTS_OUTPUT_GAIN = 1.5
 DEFAULT_PIPER_MODEL = "en_US-lessac-medium"
 DEFAULT_ANNOUNCEMENT_TTS_BACKEND = DEFAULT_TTS_BACKEND
+DEFAULT_SATELLITE_DUCKING_TARGET_PERCENT = 20
+DEFAULT_SATELLITE_DUCKING_ATTACK_MS = 150
+DEFAULT_SATELLITE_DUCKING_RELEASE_MS = 350
 
 KOKORO_MODEL_SPECS: Dict[str, Dict[str, str]] = {
     "v1.0:q8": {
@@ -82,12 +85,18 @@ def _clean(value: Any) -> str:
     return str(value or "").strip()
 
 
-def _as_int(value: Any, default: int) -> int:
+def _as_int(
+    value: Any,
+    default: int,
+    *,
+    minimum: int = 1,
+    maximum: int = 65535,
+) -> int:
     try:
         parsed = int(float(value))
     except Exception:
         parsed = int(default)
-    if parsed < 1 or parsed > 65535:
+    if parsed < int(minimum) or parsed > int(maximum):
         return int(default)
     return int(parsed)
 
@@ -513,6 +522,24 @@ def get_speech_settings() -> Dict[str, Any]:
         ),
         "announcement_tts_model": _clean(shared.get("announcement_tts_model")),
         "announcement_tts_voice": _clean(shared.get("announcement_tts_voice")),
+        "satellite_ducking_target_percent": _as_int(
+            shared.get("satellite_ducking_target_percent"),
+            DEFAULT_SATELLITE_DUCKING_TARGET_PERCENT,
+            minimum=0,
+            maximum=100,
+        ),
+        "satellite_ducking_attack_ms": _as_int(
+            shared.get("satellite_ducking_attack_ms"),
+            DEFAULT_SATELLITE_DUCKING_ATTACK_MS,
+            minimum=0,
+            maximum=10000,
+        ),
+        "satellite_ducking_release_ms": _as_int(
+            shared.get("satellite_ducking_release_ms"),
+            DEFAULT_SATELLITE_DUCKING_RELEASE_MS,
+            minimum=0,
+            maximum=10000,
+        ),
         "announcement_wyoming_tts_host": (
             _clean(shared.get("announcement_wyoming_tts_host"))
             if has_announcement_wyoming_host
@@ -629,6 +656,9 @@ def save_speech_settings(
     announcement_chatterbox_tts_seed: Any = None,
     announcement_chatterbox_tts_speed_factor: Any = None,
     announcement_chatterbox_tts_language: Any = None,
+    satellite_ducking_target_percent: Any = DEFAULT_SATELLITE_DUCKING_TARGET_PERCENT,
+    satellite_ducking_attack_ms: Any = DEFAULT_SATELLITE_DUCKING_ATTACK_MS,
+    satellite_ducking_release_ms: Any = DEFAULT_SATELLITE_DUCKING_RELEASE_MS,
     acceleration: Any = DEFAULT_SPEECH_ACCELERATION,
 ) -> None:
     direct_tts_backend = _normalize_tts_backend(tts_backend)
@@ -669,6 +699,30 @@ def save_speech_settings(
             ),
             "announcement_tts_model": _clean(announcement_tts_model),
             "announcement_tts_voice": _clean(announcement_tts_voice),
+            "satellite_ducking_target_percent": str(
+                _as_int(
+                    satellite_ducking_target_percent,
+                    DEFAULT_SATELLITE_DUCKING_TARGET_PERCENT,
+                    minimum=0,
+                    maximum=100,
+                )
+            ),
+            "satellite_ducking_attack_ms": str(
+                _as_int(
+                    satellite_ducking_attack_ms,
+                    DEFAULT_SATELLITE_DUCKING_ATTACK_MS,
+                    minimum=0,
+                    maximum=10000,
+                )
+            ),
+            "satellite_ducking_release_ms": str(
+                _as_int(
+                    satellite_ducking_release_ms,
+                    DEFAULT_SATELLITE_DUCKING_RELEASE_MS,
+                    minimum=0,
+                    maximum=10000,
+                )
+            ),
             "announcement_wyoming_tts_host": (
                 _clean(announcement_wyoming_tts_host)
                 if announcement_wyoming_tts_host is not None

--- a/speech_tts.py
+++ b/speech_tts.py
@@ -2326,6 +2326,7 @@ def _voice_core_play_media_sync(
     tts_kind: str = "",
     continue_conversation: bool = False,
     conversation_id: str = "",
+    audio_scene: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     clean_selectors = [_text(item) for item in list(selectors or []) if _text(item)]
     if not clean_selectors:
@@ -2354,10 +2355,15 @@ def _voice_core_play_media_sync(
         payload_template["continue_conversation"] = True
         if _text(conversation_id):
             payload_template["conversation_id"] = _text(conversation_id)
+    if isinstance(audio_scene, dict) and audio_scene:
+        payload_template["audio_scene"] = dict(audio_scene)
     if isinstance(audio_bytes, (bytes, bytearray)) and audio_bytes:
         payload_template["audio_b64"] = base64.b64encode(bytes(audio_bytes)).decode("ascii")
     failures = []
     sent_count = 0
+    audio_scene_sent_count = 0
+    audio_scene_fallback_count = 0
+    audio_scene_warnings: list[str] = []
 
     for selector in clean_selectors:
         payload = dict(payload_template)
@@ -2376,6 +2382,18 @@ def _voice_core_play_media_sync(
             )
             if response.status_code < 400:
                 sent_count += 1
+                response_payload: Dict[str, Any] = {}
+                with contextlib.suppress(Exception):
+                    parsed_response = response.json()
+                    if isinstance(parsed_response, dict):
+                        response_payload = parsed_response
+                if bool(response_payload.get("audio_scene_started")):
+                    audio_scene_sent_count += 1
+                elif isinstance(audio_scene, dict) and audio_scene:
+                    audio_scene_fallback_count += 1
+                    fallback_reason = _text(response_payload.get("audio_scene_fallback_reason"))
+                    if fallback_reason:
+                        audio_scene_warnings.append(f"{selector} ({fallback_reason})")
                 continue
             detail = ""
             with contextlib.suppress(Exception):
@@ -2387,7 +2405,14 @@ def _voice_core_play_media_sync(
             failures.append(f"{selector} ({exc})")
 
     if sent_count:
-        result: Dict[str, Any] = {"ok": True, "sent_count": sent_count}
+        result: Dict[str, Any] = {
+            "ok": True,
+            "sent_count": sent_count,
+            "audio_scene_sent_count": audio_scene_sent_count,
+            "audio_scene_fallback_count": audio_scene_fallback_count,
+        }
+        if audio_scene_warnings:
+            result["audio_scene_warnings"] = audio_scene_warnings
         if failures:
             result["warnings"] = failures
         return result
@@ -2605,6 +2630,7 @@ async def speak_announcement_targets(
     voice_core_wyoming_voice: str = DEFAULT_WYOMING_TTS_VOICE,
     default_backend: str = DEFAULT_ANNOUNCEMENT_TTS_BACKEND,
     tts_kind: str = "",
+    audio_scene: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     prompt = _text(text)
     if not prompt:
@@ -2734,8 +2760,16 @@ async def speak_announcement_targets(
             filename=f"tts-{selected_backend}.wav",
             timeout_s=DEFAULT_VOICE_CORE_PLAY_TIMEOUT_SECONDS,
             tts_kind=tts_kind,
+            audio_scene=audio_scene,
         )
         result["voice_core_sent_count"] = int(voice_result.get("sent_count") or 0)
+        result["audio_scene_sent_count"] = int(voice_result.get("audio_scene_sent_count") or 0)
+        result["audio_scene_fallback_count"] = int(voice_result.get("audio_scene_fallback_count") or 0)
+        result["audio_scene_warnings"] = [
+            _text(item)
+            for item in list(voice_result.get("audio_scene_warnings") or [])
+            if _text(item)
+        ]
         sent_count += int(voice_result.get("sent_count") or 0)
         warnings.extend([_text(item) for item in list(voice_result.get("warnings") or []) if _text(item)])
         if not voice_result.get("ok") and _text(voice_result.get("error")):

--- a/tater_voice/home.py
+++ b/tater_voice/home.py
@@ -12,6 +12,7 @@ from . import native_satellite
 from . import reply_playback as esphome_reply_playback
 from . import settings as esphome_settings
 from . import speaker_id as esphome_speaker_id
+from . import stereo_pairs
 from . import wake_trainer_link
 from . import emotion_id as esphome_emotion_id
 
@@ -105,6 +106,204 @@ def _global_satellite_settings_item_form(native_status: Dict[str, Any]) -> Dict[
         "save_label": "Apply To All Satellites",
         "remove_action": "",
     }
+
+
+def _stereo_pair_member_options(
+    native_status: Dict[str, Any],
+    *,
+    current_selector: str = "",
+) -> List[Dict[str, str]]:
+    clients = native_status.get("clients") if isinstance(native_status.get("clients"), dict) else {}
+    rows: List[Dict[str, str]] = [{"value": "", "label": "Select a satellite"}]
+    seen = {""}
+    required = {
+        "synchronized_media_sessions",
+        "stereo_channel_selection",
+        "media_playhead_telemetry",
+        "media_drift_correction",
+    }
+    for selector, raw in sorted(clients.items(), key=lambda item: esphome_runtime.text(item[0])):
+        if not isinstance(raw, dict) or not bool(raw.get("connected")):
+            continue
+        token = esphome_runtime.text(selector)
+        capabilities = raw.get("capabilities") if isinstance(raw.get("capabilities"), dict) else {}
+        try:
+            session_version = int(float(capabilities.get("audio_session_version") or 0))
+        except Exception:
+            session_version = 0
+        if session_version < 2 or any(not bool(capabilities.get(name)) for name in required):
+            continue
+        name = esphome_runtime.text(raw.get("device_name")) or token
+        room = esphome_runtime.text(raw.get("room"))
+        suffix = f" • {room}" if room and room.lower() != name.lower() else ""
+        rows.append({"value": token, "label": f"{name}{suffix}"})
+        seen.add(token)
+    current = esphome_runtime.text(current_selector)
+    if current and current not in seen:
+        rows.append({"value": current, "label": f"{current} (offline or update required)"})
+    return rows
+
+
+def _stereo_pair_ready(pair: Dict[str, Any], native_status: Dict[str, Any]) -> bool:
+    clients = native_status.get("clients") if isinstance(native_status.get("clients"), dict) else {}
+    for selector in (
+        esphome_runtime.text(pair.get("left_selector")),
+        esphome_runtime.text(pair.get("right_selector")),
+    ):
+        row = clients.get(selector) if isinstance(clients.get(selector), dict) else {}
+        capabilities = row.get("capabilities") if isinstance(row.get("capabilities"), dict) else {}
+        try:
+            session_version = int(float(capabilities.get("audio_session_version") or 0))
+        except Exception:
+            session_version = 0
+        if (
+            not bool(row.get("connected"))
+            or session_version < 2
+            or not bool(capabilities.get("synchronized_media_sessions"))
+            or not bool(capabilities.get("stereo_channel_selection"))
+            or not bool(capabilities.get("media_playhead_telemetry"))
+            or not bool(capabilities.get("media_drift_correction"))
+        ):
+            return False
+    return True
+
+
+def _stereo_pair_fields(pair: Dict[str, Any], native_status: Dict[str, Any]) -> List[Dict[str, Any]]:
+    left_selector = esphome_runtime.text(pair.get("left_selector"))
+    right_selector = esphome_runtime.text(pair.get("right_selector"))
+    return [
+        {
+            "key": "name",
+            "label": "Pair Name",
+            "type": "text",
+            "value": esphome_runtime.text(pair.get("name")),
+            "placeholder": "Master Bedroom Stereo",
+            "description": "This appears as one destination throughout Tater.",
+        },
+        {
+            "key": "left_selector",
+            "label": "Left Satellite",
+            "type": "select",
+            "value": left_selector,
+            "options": _stereo_pair_member_options(native_status, current_selector=left_selector),
+        },
+        {
+            "key": "right_selector",
+            "label": "Right Satellite",
+            "type": "select",
+            "value": right_selector,
+            "options": _stereo_pair_member_options(native_status, current_selector=right_selector),
+        },
+        {
+            "key": "left_volume_percent",
+            "label": "Left Balance",
+            "type": "number",
+            "value": int(
+                pair.get("left_volume_percent")
+                if pair.get("left_volume_percent") is not None
+                else 100
+            ),
+            "min": 0,
+            "max": 100,
+            "step": 1,
+            "suffix": "%",
+        },
+        {
+            "key": "right_volume_percent",
+            "label": "Right Balance",
+            "type": "number",
+            "value": int(
+                pair.get("right_volume_percent")
+                if pair.get("right_volume_percent") is not None
+                else 100
+            ),
+            "min": 0,
+            "max": 100,
+            "step": 1,
+            "suffix": "%",
+        },
+        {
+            "key": "left_delay_ms",
+            "label": "Left Delay",
+            "type": "number",
+            "value": int(pair.get("left_delay_ms") or 0),
+            "min": 0,
+            "max": 250,
+            "step": 1,
+            "suffix": "ms",
+            "description": "Optional acoustic calibration. Leave both delays at zero initially.",
+        },
+        {
+            "key": "right_delay_ms",
+            "label": "Right Delay",
+            "type": "number",
+            "value": int(pair.get("right_delay_ms") or 0),
+            "min": 0,
+            "max": 250,
+            "step": 1,
+            "suffix": "ms",
+        },
+    ]
+
+
+def _stereo_pair_item_forms(native_status: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for pair in stereo_pairs.list_pairs():
+        ready = _stereo_pair_ready(pair, native_status)
+        rows.append(
+            {
+                "id": pair.get("selector"),
+                "group": "stereo_pair",
+                "title": pair.get("name") or "Stereo Pair",
+                "subtitle": "Synchronized left/right Tater satellite pair",
+                "detail": (
+                    "Ready for synchronized playback"
+                    if ready
+                    else "Unavailable until both satellites are connected with current firmware"
+                ),
+                "connected": ready,
+                "hero_badges": [
+                    {"label": "Stereo", "tone": "active"},
+                    {"label": "Ready" if ready else "Unavailable", "tone": "active" if ready else "warning"},
+                ],
+                "summary_rows": [
+                    {"label": "Left", "value": pair.get("left_selector")},
+                    {"label": "Right", "value": pair.get("right_selector")},
+                ],
+                "fields": _stereo_pair_fields(pair, native_status),
+                "save_action": "voice_stereo_pair_save",
+                "save_label": "Save Pair",
+                "remove_action": "voice_stereo_pair_remove",
+                "remove_label": "Delete Pair",
+                "remove_confirm": f"Delete stereo pair {pair.get('name') or pair.get('id')}?",
+                "show_entity_refresh": False,
+            }
+        )
+    rows.append(
+        {
+            "id": "stereo:new",
+            "group": "stereo_pair_create",
+            "title": "Create Stereo Pair",
+            "subtitle": "Combine two updated Tater Native satellites into one synchronized destination.",
+            "detail": "Choose which satellite is physically on the left and right.",
+            "connected": False,
+            "hero_badges": [{"label": "New Pair", "tone": "muted"}],
+            "fields": _stereo_pair_fields(
+                {
+                    "name": "",
+                    "left_volume_percent": 100,
+                    "right_volume_percent": 100,
+                    "left_delay_ms": 0,
+                    "right_delay_ms": 0,
+                },
+                native_status,
+            ),
+            "save_action": "voice_stereo_pair_save",
+            "save_label": "Create Pair",
+            "show_entity_refresh": False,
+        }
+    )
+    return rows
 
 
 def _wake_trainer_link_item_form() -> Dict[str, Any]:
@@ -833,6 +1032,7 @@ def get_runtime_payload(
     ]
     if include_satellites:
         item_forms.append(esphome_settings.settings_item_form())
+        item_forms.extend(_stereo_pair_item_forms(native_status))
         item_forms.extend(esphome_settings.satellite_item_forms(status))
         payload["display_sensors"] = esphome_firmware.display_sensor_profiles_payload(status)
     payload["ui"]["item_forms"] = item_forms
@@ -1222,6 +1422,41 @@ def handle_runtime_action(*, action: str, payload: Dict[str, Any], redis_client:
         result = native_satellite.pairing_status(pairing_id)
         result["action"] = action_name
         return result
+
+    if action_name == "voice_stereo_pair_save":
+        selector = esphome_runtime.payload_selector(body)
+        values = esphome_runtime.payload_values(body)
+        compatibility = native_satellite.run_on_runtime_loop(
+            native_satellite.stereo_pair_compatibility(
+                esphome_runtime.text(values.get("left_selector")),
+                esphome_runtime.text(values.get("right_selector")),
+            ),
+            timeout=8.0,
+        )
+        if not isinstance(compatibility, dict) or not bool(compatibility.get("ok")):
+            raise ValueError(
+                esphome_runtime.text((compatibility or {}).get("error"))
+                or "The selected satellites are not ready for stereo pairing."
+            )
+        existing_id = stereo_pairs.pair_id_from_selector(selector)
+        saved = stereo_pairs.save_pair(values, pair_id=existing_id)
+        return {
+            "ok": True,
+            "action": action_name,
+            "selector": saved.get("selector"),
+            "pair": saved,
+            "message": f"Saved stereo pair {saved.get('name')}.",
+        }
+
+    if action_name == "voice_stereo_pair_remove":
+        selector = esphome_runtime.payload_selector(body)
+        removed = stereo_pairs.remove_pair(selector)
+        return {
+            "ok": True,
+            "action": action_name,
+            **removed,
+            "message": "Stereo pair deleted." if removed.get("removed") else "Stereo pair was already removed.",
+        }
 
     if action_name == "voice_native_satellite_settings_save":
         selector = esphome_runtime.payload_selector(body)

--- a/tater_voice/native_satellite.py
+++ b/tater_voice/native_satellite.py
@@ -46,6 +46,15 @@ _client_loop: Optional[asyncio.AbstractEventLoop] = None
 _client_loop_lock = threading.RLock()
 _pairing_lock = threading.RLock()
 _pairing_sessions: Dict[str, Dict[str, Any]] = {}
+_stereo_sessions: Dict[str, Dict[str, Any]] = {}
+_stereo_adjust_tasks: Dict[str, asyncio.Task] = {}
+
+STEREO_CLOCK_PROBE_COUNT = 5
+STEREO_START_LEAD_MS = 750
+STEREO_CLOCK_REFRESH_S = 60.0
+STEREO_ADJUST_INTERVAL_S = 1.0
+STEREO_ADJUST_THRESHOLD_FRAMES = 24
+STEREO_ADJUST_MAX_FRAMES = 48
 
 
 def _vp():
@@ -479,14 +488,60 @@ def _queue_command(queue: asyncio.Queue, message: Dict[str, Any]) -> None:
         queue.put_nowait(message)
 
 
-def _capabilities(payload: Dict[str, Any]) -> Dict[str, bool]:
+def _capabilities(payload: Dict[str, Any]) -> Dict[str, Any]:
     raw = payload.get("capabilities")
     if not isinstance(raw, dict):
         return {}
+    capabilities: Dict[str, Any] = {}
+    for key, value in raw.items():
+        name = _text(key)
+        if not name:
+            continue
+        if isinstance(value, str) and _lower(value) in {
+            "0",
+            "1",
+            "true",
+            "false",
+            "yes",
+            "no",
+            "on",
+            "off",
+            "enabled",
+            "disabled",
+        }:
+            capabilities[name] = _as_bool(value)
+        elif isinstance(value, (bool, int, float, str)):
+            capabilities[name] = value
+    return capabilities
+
+
+def _satellite_ducking_payload() -> Dict[str, int]:
+    try:
+        from speech_settings import get_speech_settings
+
+        settings = get_speech_settings()
+    except Exception:
+        settings = {}
+
     return {
-        _text(key): _as_bool(value)
-        for key, value in raw.items()
-        if _text(key)
+        "target_percent": _as_int(
+            settings.get("satellite_ducking_target_percent"),
+            20,
+            minimum=0,
+            maximum=100,
+        ),
+        "attack_ms": _as_int(
+            settings.get("satellite_ducking_attack_ms"),
+            150,
+            minimum=0,
+            maximum=10000,
+        ),
+        "release_ms": _as_int(
+            settings.get("satellite_ducking_release_ms"),
+            350,
+            minimum=0,
+            maximum=10000,
+        ),
     }
 
 
@@ -631,7 +686,10 @@ class _NativeVoiceAssistantClient:
 
         url = _text(data.get("url"))
         if event == "TTS_END" and url:
-            play_payload: Dict[str, Any] = {"url": url}
+            play_payload: Dict[str, Any] = {
+                "url": url,
+                "ducking": _satellite_ducking_payload(),
+            }
             if tts_kind:
                 play_payload["tts_kind"] = tts_kind
             if tool_visual:
@@ -992,6 +1050,16 @@ def _client_snapshot(selector: str, row: Dict[str, Any]) -> Dict[str, Any]:
         "last_error": _text(row.get("last_error")),
         "last_message_type": _text(row.get("last_message_type")),
         "last_status": row.get("last_status") if isinstance(row.get("last_status"), dict) else {},
+        "media_session": (
+            dict(row.get("media_session"))
+            if isinstance(row.get("media_session"), dict)
+            else {"active": False}
+        ),
+        "audio_overlay": (
+            dict(row.get("audio_overlay"))
+            if isinstance(row.get("audio_overlay"), dict)
+            else {"active": False}
+        ),
         "live_settings": _live_settings_payload(selector, board=_text(payload.get("board"))),
         "auth": {
             "mode": _text(auth.get("mode")) or "open",
@@ -1058,6 +1126,16 @@ async def client_has_capability(selector: str, capability: str) -> bool:
         payload = _message_payload(hello)
     caps = _capabilities(payload)
     return bool(caps.get(cap))
+
+
+async def client_media_session_active(selector: str) -> bool:
+    token = _text(selector)
+    if not token:
+        return False
+    async with _clients_lock:
+        row = _clients.get(token)
+        session = row.get("media_session") if isinstance(row, dict) else {}
+        return bool(isinstance(session, dict) and session.get("active"))
 
 
 async def live_settings(selector: str = "") -> Dict[str, Any]:
@@ -1168,6 +1246,545 @@ async def send_request(
             future.cancel()
 
 
+def _monotonic_us() -> int:
+    return int(time.monotonic_ns() // 1000)
+
+
+async def _stereo_clock_probe(selector: str) -> Dict[str, Any]:
+    token = _text(selector)
+    best: Dict[str, Any] = {}
+    for _index in range(STEREO_CLOCK_PROBE_COUNT):
+        server_send_us = _monotonic_us()
+        try:
+            result = await send_request(
+                token,
+                "audio.clock.sync",
+                {"server_send_us": server_send_us},
+                timeout_s=2.0,
+            )
+        except Exception:
+            continue
+        server_receive_us = _monotonic_us()
+        if not _as_bool(result.get("ok"), False):
+            continue
+        satellite_receive_us = _as_int(result.get("satellite_receive_us"), 0)
+        satellite_send_us = _as_int(result.get("satellite_send_us"), 0)
+        if satellite_receive_us <= 0 or satellite_send_us < satellite_receive_us:
+            continue
+        satellite_processing_us = satellite_send_us - satellite_receive_us
+        round_trip_us = max(
+            0,
+            (server_receive_us - server_send_us) - satellite_processing_us,
+        )
+        offset_us = int(
+            round(
+                (
+                    (satellite_receive_us - server_send_us)
+                    + (satellite_send_us - server_receive_us)
+                )
+                / 2.0
+            )
+        )
+        sample = {
+            "selector": token,
+            "offset_us": offset_us,
+            "round_trip_us": round_trip_us,
+            "server_sample_us": int((server_send_us + server_receive_us) // 2),
+            "satellite_sample_us": int((satellite_receive_us + satellite_send_us) // 2),
+        }
+        if not best or round_trip_us < int(best.get("round_trip_us") or 0):
+            best = sample
+        await asyncio.sleep(0)
+    if not best:
+        raise RuntimeError(f"Could not synchronize the playback clock for {token}.")
+    return best
+
+
+async def stereo_pair_compatibility(left_selector: str, right_selector: str) -> Dict[str, Any]:
+    left = _text(left_selector)
+    right = _text(right_selector)
+    if not left.startswith("native:") or not right.startswith("native:"):
+        return {"ok": False, "error": "Stereo pairs require two Tater Native satellites."}
+    if left == right:
+        return {"ok": False, "error": "Left and right satellites must be different."}
+
+    missing: list[str] = []
+    disconnected: list[str] = []
+    async with _clients_lock:
+        for selector in (left, right):
+            row = _clients.get(selector)
+            if not isinstance(row, dict) or not bool(row.get("connected")):
+                disconnected.append(selector)
+                continue
+            hello = row.get("hello") if isinstance(row.get("hello"), dict) else {}
+            capabilities = _capabilities(_message_payload(hello))
+            required = {
+                "synchronized_media_sessions",
+                "stereo_channel_selection",
+                "media_playhead_telemetry",
+                "media_drift_correction",
+            }
+            absent = sorted(name for name in required if not bool(capabilities.get(name)))
+            try:
+                session_version = int(float(capabilities.get("audio_session_version") or 0))
+            except Exception:
+                session_version = 0
+            if session_version < 2:
+                absent.append("audio_session_version_2")
+            if absent:
+                missing.append(f"{selector} ({', '.join(absent)})")
+    if disconnected:
+        return {
+            "ok": False,
+            "error": f"Both stereo satellites must be connected: {', '.join(disconnected)}.",
+            "disconnected": disconnected,
+        }
+    if missing:
+        return {
+            "ok": False,
+            "error": "Update satellite firmware before creating this stereo pair: " + "; ".join(missing),
+            "missing_capabilities": missing,
+        }
+    return {"ok": True, "left_selector": left, "right_selector": right}
+
+
+async def _stop_stereo_members(selectors: list[str], *, session_id: str = "") -> None:
+    async def _stop(selector: str) -> None:
+        with contextlib.suppress(Exception):
+            await send_command(
+                selector,
+                "media.session.stop",
+                {"session_id": _text(session_id), "reason": "stereo_group_stop"},
+            )
+
+    await asyncio.gather(*(_stop(selector) for selector in selectors))
+
+
+async def prepare_stereo_media_session(
+    pair: Dict[str, Any],
+    *,
+    session_id: str,
+    media_url: str,
+    volume_percent: int = 100,
+    loop: bool = False,
+    content_type: str = "music",
+    channel_mode: str = "stereo",
+) -> Dict[str, Any]:
+    pair_row = pair if isinstance(pair, dict) else {}
+    left = _text(pair_row.get("left_selector"))
+    right = _text(pair_row.get("right_selector"))
+    compatibility = await stereo_pair_compatibility(left, right)
+    if not compatibility.get("ok"):
+        raise RuntimeError(_text(compatibility.get("error")) or "Stereo pair is unavailable.")
+    if not _text(session_id) or not _text(media_url):
+        raise ValueError("session_id and media_url are required")
+
+    group_id = _text(pair_row.get("id")) or uuid.uuid4().hex[:12]
+    group_session_id = _text(session_id)
+    base_volume = max(0, min(100, _as_int(volume_percent, 100)))
+    mono = _lower(channel_mode) in {"mono", "center", "tts"}
+    member_rows = [
+        {
+            "selector": left,
+            "channel": "mono" if mono else "left",
+            "delay_ms": max(0, min(250, _as_int(pair_row.get("left_delay_ms"), 0))),
+            "volume_percent": int(
+                round(base_volume * max(0, min(100, _as_int(pair_row.get("left_volume_percent"), 100))) / 100.0)
+            ),
+        },
+        {
+            "selector": right,
+            "channel": "mono" if mono else "right",
+            "delay_ms": max(0, min(250, _as_int(pair_row.get("right_delay_ms"), 0))),
+            "volume_percent": int(
+                round(base_volume * max(0, min(100, _as_int(pair_row.get("right_volume_percent"), 100))) / 100.0)
+            ),
+        },
+    ]
+
+    clocks = await asyncio.gather(
+        _stereo_clock_probe(left),
+        _stereo_clock_probe(right),
+    )
+    clock_by_selector = {row["selector"]: row for row in clocks}
+
+    async def _prepare(member: Dict[str, Any]) -> Dict[str, Any]:
+        result = await send_request(
+            member["selector"],
+            "media.session.prepare",
+            {
+                "session_id": group_session_id,
+                "group_id": group_id,
+                "media": {
+                    "url": media_url,
+                    "volume_percent": member["volume_percent"],
+                    "loop": bool(loop),
+                    "content_type": _text(content_type) or "music",
+                },
+                "routing": {
+                    "channel": member["channel"],
+                    "pair_selector": _text(pair_row.get("selector")),
+                },
+            },
+            timeout_s=15.0,
+        )
+        if not _as_bool(result.get("ok"), False):
+            raise RuntimeError(_text(result.get("error")) or f"{member['selector']} did not prepare audio.")
+        return result
+
+    try:
+        prepared = await asyncio.gather(*(_prepare(member) for member in member_rows))
+        start_server_us = _monotonic_us() + (STEREO_START_LEAD_MS * 1000)
+
+        async def _commit(member: Dict[str, Any]) -> Dict[str, Any]:
+            clock = clock_by_selector[member["selector"]]
+            start_at_us = (
+                start_server_us
+                + int(clock["offset_us"])
+                + (int(member["delay_ms"]) * 1000)
+            )
+            result = await send_request(
+                member["selector"],
+                "media.session.commit",
+                {
+                    "session_id": group_session_id,
+                    "group_id": group_id,
+                    "start_at_us": start_at_us,
+                },
+                timeout_s=3.0,
+            )
+            if not _as_bool(result.get("ok"), False):
+                raise RuntimeError(_text(result.get("error")) or f"{member['selector']} rejected synchronized start.")
+            return {**result, "start_at_us": start_at_us}
+
+        committed = await asyncio.gather(*(_commit(member) for member in member_rows))
+    except Exception:
+        await _stop_stereo_members([left, right], session_id=group_session_id)
+        raise
+
+    _stereo_sessions[group_id] = {
+        "group_id": group_id,
+        "pair_selector": _text(pair_row.get("selector")),
+        "session_id": group_session_id,
+        "left_selector": left,
+        "right_selector": right,
+        "clock_offsets_us": {
+            selector: int(row.get("offset_us") or 0)
+            for selector, row in clock_by_selector.items()
+        },
+        "clock_round_trip_us": {
+            selector: int(row.get("round_trip_us") or 0)
+            for selector, row in clock_by_selector.items()
+        },
+        "member_delays_ms": {
+            member["selector"]: int(member.get("delay_ms") or 0)
+            for member in member_rows
+        },
+        "clock_sync_server_us": _monotonic_us(),
+        "playheads": {},
+        "last_adjust_server_us": 0,
+        "created_server_us": _monotonic_us(),
+        "loop": bool(loop),
+        "channel_mode": "mono" if mono else "stereo",
+    }
+    return {
+        "ok": True,
+        "stereo_session_started": True,
+        "group_id": group_id,
+        "session_id": group_session_id,
+        "members": member_rows,
+        "prepared": prepared,
+        "committed": committed,
+        "start_server_us": start_server_us,
+        "clock_samples": clocks,
+    }
+
+
+def stereo_pair_media_active(pair: Dict[str, Any]) -> bool:
+    pair_selector = _text((pair or {}).get("selector"))
+    for session in _stereo_sessions.values():
+        if (
+            isinstance(session, dict)
+            and _text(session.get("pair_selector")) == pair_selector
+        ):
+            return True
+    return False
+
+
+async def start_stereo_overlay(
+    pair: Dict[str, Any],
+    *,
+    overlay_id: str,
+    foreground_url: str,
+    foreground_kind: str = "tts",
+    foreground_volume_percent: int = 100,
+    ducking: Optional[Dict[str, Any]] = None,
+    start_server_us: int = 0,
+    stop_media_when_finished: bool = False,
+) -> Dict[str, Any]:
+    pair_row = pair if isinstance(pair, dict) else {}
+    left = _text(pair_row.get("left_selector"))
+    right = _text(pair_row.get("right_selector"))
+    compatibility = await stereo_pair_compatibility(left, right)
+    if not compatibility.get("ok"):
+        raise RuntimeError(_text(compatibility.get("error")) or "Stereo pair is unavailable.")
+
+    pair_selector = _text(pair_row.get("selector"))
+    session = next(
+        (
+            row
+            for row in _stereo_sessions.values()
+            if isinstance(row, dict) and _text(row.get("pair_selector")) == pair_selector
+        ),
+        None,
+    )
+    if not isinstance(session, dict):
+        raise RuntimeError("The stereo pair does not have an active synchronized media session.")
+
+    requested_start_server_us = _as_int(start_server_us, 0)
+    minimum_start_server_us = _monotonic_us() + 100_000
+    if requested_start_server_us >= minimum_start_server_us:
+        offsets = (
+            session.get("clock_offsets_us")
+            if isinstance(session.get("clock_offsets_us"), dict)
+            else {}
+        )
+        clocks = [
+            {"selector": left, "offset_us": _as_int(offsets.get(left), 0)},
+            {"selector": right, "offset_us": _as_int(offsets.get(right), 0)},
+        ]
+        synchronized_start_server_us = requested_start_server_us
+    else:
+        clocks = await asyncio.gather(_stereo_clock_probe(left), _stereo_clock_probe(right))
+        synchronized_start_server_us = _monotonic_us() + (STEREO_START_LEAD_MS * 1000)
+    duck = ducking if isinstance(ducking, dict) else {}
+    base_volume = max(0, min(100, _as_int(foreground_volume_percent, 100)))
+    member_settings = {
+        left: {
+            "delay_ms": max(0, min(250, _as_int(pair_row.get("left_delay_ms"), 0))),
+            "volume_percent": int(
+                round(base_volume * max(0, min(100, _as_int(pair_row.get("left_volume_percent"), 100))) / 100.0)
+            ),
+        },
+        right: {
+            "delay_ms": max(0, min(250, _as_int(pair_row.get("right_delay_ms"), 0))),
+            "volume_percent": int(
+                round(base_volume * max(0, min(100, _as_int(pair_row.get("right_volume_percent"), 100))) / 100.0)
+            ),
+        },
+    }
+
+    async def _start(clock: Dict[str, Any]) -> Dict[str, Any]:
+        selector = _text(clock.get("selector"))
+        settings = member_settings.get(selector) or {}
+        start_at_us = (
+            synchronized_start_server_us
+            + int(clock.get("offset_us") or 0)
+            + (_as_int(settings.get("delay_ms"), 0) * 1000)
+        )
+        result = await send_command(
+            selector,
+            "audio.overlay.start",
+            {
+                "overlay_id": _text(overlay_id),
+                "foreground": {
+                    "url": _text(foreground_url),
+                    "kind": _text(foreground_kind) or "tts",
+                    "volume_percent": _as_int(settings.get("volume_percent"), base_volume),
+                },
+                "ducking": dict(duck),
+                "start_at_us": start_at_us,
+                "group_id": _text(session.get("group_id")),
+            },
+        )
+        return {**result, "start_at_us": start_at_us}
+
+    members = await asyncio.gather(*(_start(clock) for clock in clocks))
+    if stop_media_when_finished:
+        session["stop_on_overlay_id"] = _text(overlay_id)
+        session["overlay_finished_selectors"] = []
+        session["stop_requested"] = False
+    return {
+        "ok": True,
+        "stereo_overlay_started": True,
+        "overlay_id": _text(overlay_id),
+        "group_id": _text(session.get("group_id")),
+        "start_server_us": synchronized_start_server_us,
+        "stop_media_when_finished": bool(stop_media_when_finished),
+        "members": members,
+    }
+
+
+async def _refresh_stereo_clocks(session: Dict[str, Any]) -> None:
+    left = _text(session.get("left_selector"))
+    right = _text(session.get("right_selector"))
+    clocks = await asyncio.gather(
+        _stereo_clock_probe(left),
+        _stereo_clock_probe(right),
+        return_exceptions=True,
+    )
+    offsets = dict(session.get("clock_offsets_us") or {})
+    round_trips = dict(session.get("clock_round_trip_us") or {})
+    updated = False
+    for row in clocks:
+        if not isinstance(row, dict):
+            continue
+        selector = _text(row.get("selector"))
+        if not selector:
+            continue
+        offsets[selector] = int(row.get("offset_us") or 0)
+        round_trips[selector] = int(row.get("round_trip_us") or 0)
+        updated = True
+    if updated:
+        session["clock_offsets_us"] = offsets
+        session["clock_round_trip_us"] = round_trips
+        session["clock_sync_server_us"] = _monotonic_us()
+
+
+async def _adjust_stereo_session(group_id: str) -> None:
+    try:
+        session = _stereo_sessions.get(group_id)
+        if not isinstance(session, dict):
+            return
+        now_us = _monotonic_us()
+        last_clock_sync_us = int(session.get("clock_sync_server_us") or 0)
+        if now_us - last_clock_sync_us >= int(STEREO_CLOCK_REFRESH_S * 1_000_000):
+            await _refresh_stereo_clocks(session)
+            now_us = _monotonic_us()
+
+        playheads = session.get("playheads") if isinstance(session.get("playheads"), dict) else {}
+        left = _text(session.get("left_selector"))
+        right = _text(session.get("right_selector"))
+        left_row = playheads.get(left) if isinstance(playheads.get(left), dict) else {}
+        right_row = playheads.get(right) if isinstance(playheads.get(right), dict) else {}
+        if not left_row or not right_row:
+            return
+        if _text(left_row.get("session_id")) != _text(session.get("session_id")):
+            return
+        if _text(right_row.get("session_id")) != _text(session.get("session_id")):
+            return
+        if now_us - int(session.get("last_adjust_server_us") or 0) < int(
+            STEREO_ADJUST_INTERVAL_S * 1_000_000
+        ):
+            return
+
+        offsets = session.get("clock_offsets_us") if isinstance(session.get("clock_offsets_us"), dict) else {}
+
+        def _projected_source_frames(selector: str, row: Dict[str, Any]) -> float:
+            sample_rate = max(1, _as_int(row.get("sample_rate_hz"), 48000))
+            satellite_time_us = _as_int(row.get("satellite_time_us"), 0)
+            server_event_us = satellite_time_us - _as_int(offsets.get(selector), 0)
+            age_us = max(0, min(2_000_000, now_us - server_event_us))
+            return float(_as_int(row.get("source_frames"), 0)) + (
+                float(age_us) * float(sample_rate) / 1_000_000.0
+            )
+
+        left_frames = _projected_source_frames(left, left_row)
+        right_frames = _projected_source_frames(right, right_row)
+        member_delays = (
+            session.get("member_delays_ms")
+            if isinstance(session.get("member_delays_ms"), dict)
+            else {}
+        )
+        sample_rate = max(1, _as_int(left_row.get("sample_rate_hz"), 48000))
+        target_delta_frames = (
+            (
+                _as_int(member_delays.get(right), 0)
+                - _as_int(member_delays.get(left), 0)
+            )
+            * sample_rate
+            / 1000.0
+        )
+        phase_error_frames = (left_frames - right_frames) - target_delta_frames
+        correction = int(round(phase_error_frames))
+        if abs(correction) < STEREO_ADJUST_THRESHOLD_FRAMES:
+            return
+        correction = max(-STEREO_ADJUST_MAX_FRAMES, min(STEREO_ADJUST_MAX_FRAMES, correction))
+        result = await send_request(
+            right,
+            "media.session.adjust",
+            {
+                "session_id": _text(session.get("session_id")),
+                "group_id": group_id,
+                "correction_frames": correction,
+                "reference_selector": left,
+            },
+            timeout_s=2.0,
+        )
+        if _as_bool(result.get("ok"), False):
+            session["last_adjust_server_us"] = now_us
+            session["last_correction_frames"] = correction
+            session["last_phase_error_frames"] = phase_error_frames
+    finally:
+        _stereo_adjust_tasks.pop(group_id, None)
+
+
+def _record_stereo_playhead(selector: str, payload: Dict[str, Any]) -> None:
+    group_id = _text(payload.get("group_id"))
+    session = _stereo_sessions.get(group_id)
+    if not group_id or not isinstance(session, dict):
+        return
+    if selector not in {_text(session.get("left_selector")), _text(session.get("right_selector"))}:
+        return
+    playheads = session.setdefault("playheads", {})
+    if not isinstance(playheads, dict):
+        playheads = {}
+        session["playheads"] = playheads
+    playheads[selector] = {**dict(payload), "received_server_us": _monotonic_us()}
+    task = _stereo_adjust_tasks.get(group_id)
+    if isinstance(task, asyncio.Task) and not task.done():
+        return
+    _stereo_adjust_tasks[group_id] = asyncio.create_task(_adjust_stereo_session(group_id))
+
+
+def _record_stereo_finished(selector: str, payload: Dict[str, Any]) -> None:
+    session_id = _text(payload.get("session_id"))
+    for group_id, session in list(_stereo_sessions.items()):
+        if not isinstance(session, dict) or _text(session.get("session_id")) != session_id:
+            continue
+        finished = session.setdefault("finished_selectors", [])
+        if not isinstance(finished, list):
+            finished = []
+            session["finished_selectors"] = finished
+        if selector not in finished:
+            finished.append(selector)
+        members = {_text(session.get("left_selector")), _text(session.get("right_selector"))}
+        if members and members.issubset(set(finished)):
+            _stereo_sessions.pop(group_id, None)
+            task = _stereo_adjust_tasks.pop(group_id, None)
+            if isinstance(task, asyncio.Task) and not task.done():
+                task.cancel()
+
+
+def _record_stereo_overlay_finished(selector: str, payload: Dict[str, Any]) -> None:
+    overlay_id = _text(payload.get("overlay_id"))
+    if not overlay_id:
+        return
+    for session in list(_stereo_sessions.values()):
+        if not isinstance(session, dict) or _text(session.get("stop_on_overlay_id")) != overlay_id:
+            continue
+        members = {_text(session.get("left_selector")), _text(session.get("right_selector"))}
+        if selector not in members:
+            continue
+        finished = session.setdefault("overlay_finished_selectors", [])
+        if not isinstance(finished, list):
+            finished = []
+            session["overlay_finished_selectors"] = finished
+        if selector not in finished:
+            finished.append(selector)
+        if members and members.issubset(set(finished)) and not _as_bool(
+            session.get("stop_requested"),
+            False,
+        ):
+            session["stop_requested"] = True
+            asyncio.create_task(
+                _stop_stereo_members(
+                    sorted(members),
+                    session_id=_text(session.get("session_id")),
+                )
+            )
+
+
 async def push_live_settings(selector: str = "") -> Dict[str, Any]:
     token = _text(selector)
     response_board = ""
@@ -1232,6 +1849,8 @@ async def _record_client(selector: str, websocket: WebSocket, hello: Dict[str, A
         "last_seen_ts": now_ts,
         "last_message_type": "hello",
         "last_status": {},
+        "media_session": {"active": False},
+        "audio_overlay": {"active": False},
         "logs": deque(maxlen=MAX_LOG_ROWS),
         "log_seq": 0,
         "binary_frames": 0,
@@ -1312,6 +1931,57 @@ async def _handle_text_message(selector: str, message: Dict[str, Any]) -> Option
                 row["last_error"] = f"setup state: {_status_state(payload)}"
                 hello = row.get("hello") if isinstance(row.get("hello"), dict) else {}
                 hello_payload = _message_payload(hello)
+        elif msg_type == "media.session.started":
+            row["media_session"] = {
+                "active": True,
+                "session_id": _text(payload.get("session_id")),
+                "group_id": _text(payload.get("group_id")),
+                "channel": _text(payload.get("channel")) or "stereo",
+                "sample_rate_hz": _as_int(payload.get("sample_rate_hz"), 48000),
+                "scheduled_start_us": _as_int(payload.get("scheduled_start_us"), 0),
+                "actual_start_us": _as_int(payload.get("actual_start_us"), 0),
+                "late_by_us": _as_int(payload.get("late_by_us"), 0),
+                "started_ts": _now(),
+            }
+        elif msg_type == "media.session.playhead":
+            previous = row.get("media_session") if isinstance(row.get("media_session"), dict) else {}
+            row["media_session"] = {
+                **previous,
+                "active": True,
+                "session_id": _text(payload.get("session_id") or previous.get("session_id")),
+                "group_id": _text(payload.get("group_id") or previous.get("group_id")),
+                "channel": _text(payload.get("channel") or previous.get("channel")) or "stereo",
+                "playhead": dict(payload),
+                "playhead_ts": _now(),
+            }
+            _record_stereo_playhead(selector, payload)
+        elif msg_type == "media.session.finished":
+            previous = row.get("media_session") if isinstance(row.get("media_session"), dict) else {}
+            row["media_session"] = {
+                **previous,
+                "active": False,
+                "session_id": _text(payload.get("session_id") or previous.get("session_id")),
+                "ok": _as_bool(payload.get("ok"), False),
+                "finished_ts": _now(),
+            }
+            row["audio_overlay"] = {"active": False}
+            _record_stereo_finished(selector, payload)
+        elif msg_type == "audio.overlay.started":
+            row["audio_overlay"] = {
+                "active": True,
+                "overlay_id": _text(payload.get("overlay_id")),
+                "started_ts": _now(),
+            }
+        elif msg_type == "audio.overlay.finished":
+            previous = row.get("audio_overlay") if isinstance(row.get("audio_overlay"), dict) else {}
+            row["audio_overlay"] = {
+                **previous,
+                "active": False,
+                "overlay_id": _text(payload.get("overlay_id") or previous.get("overlay_id")),
+                "ok": _as_bool(payload.get("ok"), False),
+                "finished_ts": _now(),
+            }
+            _record_stereo_overlay_finished(selector, payload)
         elif msg_type in {"log", "ota.status"}:
             logs_deque = row.get("logs")
             if isinstance(logs_deque, deque):
@@ -1365,11 +2035,23 @@ async def _handle_text_message(selector: str, message: Dict[str, Any]) -> Option
             await bridge.voice_stop(payload)
         return _envelope("voice.stop.ack", {"ok": True}, message_id=_text(message.get("id")))
 
-    if msg_type in {"announcement.finished", "playback.finished", "tts.finished"}:
+    if msg_type in {
+        "announcement.finished",
+        "playback.finished",
+        "tts.finished",
+        "audio.scene.finished",
+        "audio.overlay.finished",
+    }:
         bridge = await _voice_bridge(selector)
         if bridge is not None:
             await bridge.announcement_finished()
-        return _envelope("announcement.finished.ack", {"ok": True}, message_id=_text(message.get("id")))
+        if msg_type == "audio.scene.finished":
+            ack_type = "audio.scene.finished.ack"
+        elif msg_type == "audio.overlay.finished":
+            ack_type = "audio.overlay.finished.ack"
+        else:
+            ack_type = "announcement.finished.ack"
+        return _envelope(ack_type, {"ok": True}, message_id=_text(message.get("id")))
 
     if msg_type == "timer.event":
         from . import native_timers

--- a/tater_voice/stereo_pairs.py
+++ b/tater_voice/stereo_pairs.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Any, Dict, List
+
+from helpers import redis_client
+
+REDIS_STEREO_PAIRS_KEY = "tater:voice:stereo_pairs:v1"
+STEREO_SELECTOR_PREFIX = "stereo:"
+_PAIR_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{5,63}$")
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _native_selector(value: Any) -> str:
+    token = _text(value)
+    return token if token.startswith("native:") else ""
+
+
+def _integer(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        result = int(float(value))
+    except Exception:
+        result = int(default)
+    return max(int(minimum), min(int(maximum), result))
+
+
+def pair_selector(pair_id: Any) -> str:
+    token = _text(pair_id)
+    if token.startswith(STEREO_SELECTOR_PREFIX):
+        return token
+    return f"{STEREO_SELECTOR_PREFIX}{token}" if token else ""
+
+
+def pair_id_from_selector(selector: Any) -> str:
+    token = _text(selector)
+    if token.startswith(STEREO_SELECTOR_PREFIX):
+        return _text(token[len(STEREO_SELECTOR_PREFIX) :])
+    return token if _PAIR_ID_RE.match(token) else ""
+
+
+def is_stereo_selector(selector: Any) -> bool:
+    return bool(pair_id_from_selector(selector) and _text(selector).startswith(STEREO_SELECTOR_PREFIX))
+
+
+def _load_document() -> Dict[str, Any]:
+    try:
+        raw = redis_client.get(REDIS_STEREO_PAIRS_KEY)
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", errors="replace")
+        parsed = json.loads(str(raw)) if raw else {}
+    except Exception:
+        parsed = {}
+    if not isinstance(parsed, dict):
+        parsed = {}
+    rows = parsed.get("pairs") if isinstance(parsed.get("pairs"), list) else []
+    return {"version": 1, "pairs": [dict(row) for row in rows if isinstance(row, dict)]}
+
+
+def _save_document(document: Dict[str, Any]) -> None:
+    rows = document.get("pairs") if isinstance(document.get("pairs"), list) else []
+    redis_client.set(
+        REDIS_STEREO_PAIRS_KEY,
+        json.dumps({"version": 1, "pairs": rows}, ensure_ascii=False),
+    )
+
+
+def list_pairs() -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for raw in _load_document()["pairs"]:
+        pair_id = pair_id_from_selector(raw.get("id") or raw.get("selector"))
+        left_selector = _native_selector(raw.get("left_selector"))
+        right_selector = _native_selector(raw.get("right_selector"))
+        if not pair_id or not left_selector or not right_selector or left_selector == right_selector:
+            continue
+        rows.append(
+            {
+                "id": pair_id,
+                "selector": pair_selector(pair_id),
+                "name": _text(raw.get("name")) or "Stereo Pair",
+                "left_selector": left_selector,
+                "right_selector": right_selector,
+                "left_delay_ms": _integer(raw.get("left_delay_ms"), 0, 0, 250),
+                "right_delay_ms": _integer(raw.get("right_delay_ms"), 0, 0, 250),
+                "left_volume_percent": _integer(raw.get("left_volume_percent"), 100, 0, 100),
+                "right_volume_percent": _integer(raw.get("right_volume_percent"), 100, 0, 100),
+            }
+        )
+    rows.sort(key=lambda row: (_text(row.get("name")).lower(), _text(row.get("id"))))
+    return rows
+
+
+def get_pair(selector_or_id: Any) -> Dict[str, Any]:
+    wanted = pair_id_from_selector(selector_or_id)
+    if not wanted:
+        return {}
+    for row in list_pairs():
+        if row.get("id") == wanted:
+            return dict(row)
+    return {}
+
+
+def save_pair(values: Dict[str, Any], *, pair_id: Any = "") -> Dict[str, Any]:
+    data = values if isinstance(values, dict) else {}
+    existing_id = pair_id_from_selector(pair_id)
+    normalized_id = existing_id or uuid.uuid4().hex[:12]
+    if not _PAIR_ID_RE.match(normalized_id):
+        raise ValueError("Stereo pair id is invalid.")
+
+    name = _text(data.get("name"))[:80]
+    left_selector = _native_selector(data.get("left_selector"))
+    right_selector = _native_selector(data.get("right_selector"))
+    if not name:
+        raise ValueError("Stereo pair name is required.")
+    if not left_selector or not right_selector:
+        raise ValueError("Choose two Tater Native satellites.")
+    if left_selector == right_selector:
+        raise ValueError("Left and right satellites must be different.")
+
+    rows = list_pairs()
+    for row in rows:
+        if row.get("id") == normalized_id:
+            continue
+        occupied = {row.get("left_selector"), row.get("right_selector")}
+        if left_selector in occupied or right_selector in occupied:
+            raise ValueError(
+                f"A satellite is already assigned to the stereo pair {row.get('name') or row.get('id')}."
+            )
+
+    saved = {
+        "id": normalized_id,
+        "selector": pair_selector(normalized_id),
+        "name": name,
+        "left_selector": left_selector,
+        "right_selector": right_selector,
+        "left_delay_ms": _integer(data.get("left_delay_ms"), 0, 0, 250),
+        "right_delay_ms": _integer(data.get("right_delay_ms"), 0, 0, 250),
+        "left_volume_percent": _integer(data.get("left_volume_percent"), 100, 0, 100),
+        "right_volume_percent": _integer(data.get("right_volume_percent"), 100, 0, 100),
+    }
+    updated = [row for row in rows if row.get("id") != normalized_id]
+    updated.append(saved)
+    _save_document({"version": 1, "pairs": updated})
+    return dict(saved)
+
+
+def remove_pair(selector_or_id: Any) -> Dict[str, Any]:
+    wanted = pair_id_from_selector(selector_or_id)
+    if not wanted:
+        raise ValueError("Stereo pair id is required.")
+    rows = list_pairs()
+    kept = [row for row in rows if row.get("id") != wanted]
+    removed = len(kept) != len(rows)
+    if removed:
+        _save_document({"version": 1, "pairs": kept})
+    return {"ok": True, "removed": removed, "id": wanted, "selector": pair_selector(wanted)}

--- a/tater_voice/voice_pipeline/__init__.py
+++ b/tater_voice/voice_pipeline/__init__.py
@@ -4464,6 +4464,35 @@ def _service_host_for_peer(peer_host: str) -> str:
     return "127.0.0.1"
 
 
+def _service_base_url_from_value(value: Any) -> str:
+    token = _text(value).strip().rstrip("/")
+    if not token:
+        return ""
+    if token.lower().startswith(("http://", "https://")):
+        return token
+
+    authority, separator, path = token.partition("/")
+    if authority.count(":") > 1 and not authority.startswith("["):
+        authority = f"[{authority}]"
+
+    has_explicit_port = (
+        (authority.startswith("[") and "]:" in authority)
+        or (not authority.startswith("[") and authority.count(":") == 1)
+    )
+    if not has_explicit_port:
+        authority = f"{authority}:{_main_app_port()}"
+
+    suffix = f"/{path.rstrip('/')}" if separator and path else ""
+    return f"http://{authority}{suffix}"
+
+
+def _service_base_url_for_peer(peer_host: str) -> str:
+    public_base_url = _text(os.getenv("VOICE_CORE_PUBLIC_BASE_URL"))
+    if public_base_url:
+        return _service_base_url_from_value(public_base_url)
+    return _service_base_url_from_value(_service_host_for_peer(peer_host))
+
+
 def _selector_host(selector: str) -> str:
     token = _text(selector)
     if token.startswith("host:"):
@@ -4497,8 +4526,8 @@ def _store_tts_url(selector: str, session_id: str, audio_bytes: bytes, audio_for
             "wav_bytes": wav_bytes,
         }
 
-    host = _service_host_for_peer(_selector_host(selector))
-    url = f"http://{host}:{_main_app_port()}/api/tater/satellite/v1/tts/{stream_id}.wav"
+    base_url = _service_base_url_for_peer(_selector_host(selector))
+    url = f"{base_url}/api/tater/satellite/v1/tts/{stream_id}.wav"
     _native_debug(
         f"native tts url prepared selector={_text(selector)} session_id={_text(session_id)} bytes={len(wav_bytes)} url={url}"
     )
@@ -4548,8 +4577,8 @@ def _store_chatterbox_tts_stream_url(
             "max_bytes": DEFAULT_CHATTERBOX_TTS_STREAM_MAX_BYTES,
         }
 
-    host = _service_host_for_peer(_selector_host(selector))
-    url = f"http://{host}:{_main_app_port()}/api/tater/satellite/v1/tts/{stream_id}.wav"
+    base_url = _service_base_url_for_peer(_selector_host(selector))
+    url = f"{base_url}/api/tater/satellite/v1/tts/{stream_id}.wav"
     _native_debug(
         f"chatterbox streaming tts url prepared selector={_text(selector)} session_id={_text(session_id)} "
         f"stream_id={stream_id} url={url}"
@@ -4597,8 +4626,8 @@ def _store_media_url(
             "body_bytes": data,
         }
 
-    host = _service_host_for_peer(_selector_host(selector))
-    url = f"http://{host}:{_main_app_port()}/api/tater/satellite/v1/media/{stream_id}"
+    base_url = _service_base_url_for_peer(_selector_host(selector))
+    url = f"{base_url}/api/tater/satellite/v1/media/{stream_id}"
     _native_debug(
         f"native media url prepared selector={_text(selector)} session_id={_text(session_id)} "
         f"bytes={len(data)} media_type={mime} url={url}"

--- a/tater_voice/voice_pipeline/routes.py
+++ b/tater_voice/voice_pipeline/routes.py
@@ -701,10 +701,79 @@ async def wyoming_tts_voices_refresh(x_tater_token: Optional[str] = Header(None)
     return {"ok": True, **result}
 
 
+def _native_audio_scene_payload(raw: Any) -> Dict[str, Any]:
+    vp = _vp()
+    scene = raw if isinstance(raw, dict) else {}
+    background = scene.get("background") if isinstance(scene.get("background"), dict) else {}
+    ducking = scene.get("ducking") if isinstance(scene.get("ducking"), dict) else {}
+    finish = scene.get("finish") if isinstance(scene.get("finish"), dict) else {}
+    background_url = vp._text(background.get("url") or scene.get("background_url"))
+    if not background_url:
+        return {}
+
+    def _percent(value: Any, default: int) -> int:
+        return max(0, min(100, int(vp._as_float(value, float(default)))))
+
+    def _milliseconds(value: Any, default: int) -> int:
+        return max(0, min(10000, int(vp._as_float(value, float(default)))))
+
+    scene_id = vp._text(scene.get("scene_id"))[:64]
+    normalized: Dict[str, Any] = {
+        "background": {
+            "url": background_url,
+            "loop": vp._as_bool(background.get("loop"), True),
+            "volume_percent": _percent(background.get("volume_percent"), 60),
+        },
+        "foreground": {
+            "volume_percent": _percent(
+                (scene.get("foreground") or {}).get("volume_percent")
+                if isinstance(scene.get("foreground"), dict)
+                else None,
+                100,
+            ),
+        },
+        "ducking": {
+            "target_percent": _percent(ducking.get("target_percent"), 35),
+            "attack_ms": _milliseconds(ducking.get("attack_ms"), 150),
+            "release_ms": _milliseconds(ducking.get("release_ms"), 350),
+        },
+        "finish": {
+            "fade_ms": _milliseconds(finish.get("fade_ms"), 500),
+        },
+    }
+    if scene_id:
+        normalized["scene_id"] = scene_id
+    return normalized
+
+
+def _native_ducking_payload(raw: Any = None) -> Dict[str, int]:
+    vp = _vp()
+    source = raw if isinstance(raw, dict) else {}
+    try:
+        from speech_settings import get_speech_settings
+
+        settings = get_speech_settings()
+    except Exception:
+        settings = {}
+
+    def _number(key: str, default: int, maximum: int) -> int:
+        value = source.get(key)
+        if value is None:
+            value = settings.get(f"satellite_ducking_{key}")
+        return max(0, min(maximum, int(vp._as_float(value, float(default)))))
+
+    return {
+        "target_percent": _number("target_percent", 20, 100),
+        "attack_ms": _number("attack_ms", 150, 10000),
+        "release_ms": _number("release_ms", 350, 10000),
+    }
+
+
 @router.post("/api/tater/satellite/v1/play")
 async def native_satellite_play(payload: Dict[str, Any], x_tater_token: Optional[str] = Header(None)) -> Dict[str, Any]:
     vp = _vp()
     vp._require_api_auth(x_tater_token)
+    from .. import stereo_pairs
 
     selector = vp._text(payload.get("selector"))
     source_url = vp._text(payload.get("source_url"))
@@ -716,10 +785,23 @@ async def native_satellite_play(payload: Dict[str, Any], x_tater_token: Optional
     conversation_id = vp._text(payload.get("conversation_id"))
     filename = vp._text(payload.get("filename")) or "audio.bin"
     requested_media_type = vp._text(payload.get("media_type")).split(";", 1)[0].strip().lower()
+    media_content_type = vp._text(payload.get("media_content_type")).lower()
+    playback_role = vp._text(payload.get("playback_role")).lower()
+    persistent_media_requested = playback_role in {"media", "music", "background"}
+    media_loop = vp._as_bool(payload.get("loop"), False)
+    media_volume_percent = max(
+        0,
+        min(100, int(vp._as_float(payload.get("volume_percent"), 100.0))),
+    )
+    ducking = _native_ducking_payload(payload.get("ducking"))
     timeout_s = vp._as_float(payload.get("timeout_s"), 180.0)
+    audio_scene = _native_audio_scene_payload(payload.get("audio_scene"))
 
     if not selector:
         raise HTTPException(status_code=400, detail="selector is required")
+    stereo_pair = stereo_pairs.get_pair(selector) if stereo_pairs.is_stereo_selector(selector) else {}
+    if stereo_pairs.is_stereo_selector(selector) and not stereo_pair:
+        raise HTTPException(status_code=404, detail="Stereo pair was not found")
     if not source_url and not audio_b64:
         raise HTTPException(status_code=400, detail="source_url or audio_b64 is required")
 
@@ -765,6 +847,7 @@ async def native_satellite_play(payload: Dict[str, Any], x_tater_token: Optional
             "selector": selector,
             "source_url": source_url,
             "media_type": media_type,
+            "media_content_type": media_content_type,
             "playback_mode": "silent",
             "reply_playback_target": reply_playback_target,
         }
@@ -799,8 +882,13 @@ async def native_satellite_play(payload: Dict[str, Any], x_tater_token: Optional
             "selector": selector,
             "source_url": source_url,
             "media_type": media_type,
+            "media_content_type": media_content_type,
             "playback_mode": "reply_playback_external",
             "reply_playback_target": reply_playback_target,
+            "audio_scene_started": False,
+            "audio_scene_fallback_reason": "External reply playback does not support satellite audio scenes."
+            if audio_scene
+            else "",
             **result,
         }
 
@@ -815,18 +903,221 @@ async def native_satellite_play(payload: Dict[str, Any], x_tater_token: Optional
     if not playback_url:
         raise HTTPException(status_code=500, detail="Failed to store media for playback")
 
-    if selector.startswith("native:"):
+    audio_scene_started = False
+    audio_scene_fallback_reason = ""
+    media_session_started = False
+    media_session_fallback_reason = ""
+    audio_overlay_started = False
+    if stereo_pair:
         try:
             from .. import native_satellite
 
-            command_payload: Dict[str, Any] = {"url": playback_url}
-            if tts_kind:
-                command_payload["tts_kind"] = tts_kind
-            if continue_conversation:
-                command_payload["continue_conversation"] = True
-            if conversation_id:
-                command_payload["conversation_id"] = conversation_id
-            result = await native_satellite.send_command(selector, "play.url", command_payload)
+            if audio_scene:
+                background = (
+                    audio_scene.get("background")
+                    if isinstance(audio_scene.get("background"), dict)
+                    else {}
+                )
+                background_source_url = vp._text(background.get("url"))
+                background_bytes, background_media_type = await vp._download_media_source(
+                    background_source_url
+                )
+                background_url = vp._store_media_url(
+                    selector,
+                    f"{playback_id}-background",
+                    background_bytes,
+                    media_type=background_media_type or "application/octet-stream",
+                    filename="background-audio",
+                )
+                if not background_url:
+                    raise RuntimeError("Failed to store stereo background audio for playback")
+                background_result = await native_satellite.prepare_stereo_media_session(
+                    stereo_pair,
+                    session_id=f"{playback_id}-background",
+                    media_url=background_url,
+                    volume_percent=int(background.get("volume_percent", 60)),
+                    loop=bool(background.get("loop", True)),
+                    content_type="background",
+                    channel_mode="stereo",
+                )
+                foreground = (
+                    audio_scene.get("foreground")
+                    if isinstance(audio_scene.get("foreground"), dict)
+                    else {}
+                )
+                overlay_result = await native_satellite.start_stereo_overlay(
+                    stereo_pair,
+                    overlay_id=playback_id,
+                    foreground_url=playback_url,
+                    foreground_kind=tts_kind or "tts",
+                    foreground_volume_percent=int(foreground.get("volume_percent", 100)),
+                    ducking=dict(audio_scene.get("ducking") or {}),
+                    start_server_us=int(background_result.get("start_server_us") or 0),
+                    stop_media_when_finished=True,
+                )
+                result = {
+                    **background_result,
+                    "overlay": overlay_result,
+                    "stereo_audio_scene_started": True,
+                }
+                audio_scene_started = True
+                media_session_started = True
+                audio_overlay_started = True
+            elif persistent_media_requested:
+                result = await native_satellite.prepare_stereo_media_session(
+                    stereo_pair,
+                    session_id=playback_id,
+                    media_url=playback_url,
+                    volume_percent=media_volume_percent,
+                    loop=media_loop,
+                    content_type=media_content_type or "music",
+                    channel_mode="stereo",
+                )
+                media_session_started = True
+            elif native_satellite.stereo_pair_media_active(stereo_pair):
+                result = await native_satellite.start_stereo_overlay(
+                    stereo_pair,
+                    overlay_id=playback_id,
+                    foreground_url=playback_url,
+                    foreground_kind=tts_kind or "tts",
+                    ducking=ducking,
+                )
+                audio_overlay_started = True
+            else:
+                result = await native_satellite.prepare_stereo_media_session(
+                    stereo_pair,
+                    session_id=playback_id,
+                    media_url=playback_url,
+                    volume_percent=100,
+                    loop=False,
+                    content_type="tts",
+                    channel_mode="mono",
+                )
+                media_session_started = True
+        except Exception as exc:
+            raise HTTPException(status_code=409, detail=f"Failed to queue stereo-pair playback: {exc}") from exc
+    elif selector.startswith("native:"):
+        try:
+            from .. import native_satellite
+
+            scene_supported = bool(audio_scene) and await native_satellite.client_has_capability(
+                selector,
+                "audio_scenes",
+            )
+            if audio_scene and scene_supported:
+                try:
+                    background = audio_scene.get("background") if isinstance(audio_scene.get("background"), dict) else {}
+                    background_source_url = vp._text(background.get("url"))
+                    background_bytes, background_media_type = await vp._download_media_source(background_source_url)
+                    background_url = vp._store_media_url(
+                        selector,
+                        playback_id,
+                        background_bytes,
+                        media_type=background_media_type or "application/octet-stream",
+                        filename="background-audio",
+                    )
+                    if not background_url:
+                        raise RuntimeError("Failed to store background audio for playback")
+
+                    command_payload = {
+                        "scene_id": vp._text(audio_scene.get("scene_id")) or playback_id,
+                        "foreground": {
+                            "url": playback_url,
+                            "kind": tts_kind or "tts",
+                            "volume_percent": int((audio_scene.get("foreground") or {}).get("volume_percent", 100)),
+                        },
+                        "background": {
+                            "url": background_url,
+                            "loop": bool(background.get("loop", True)),
+                            "volume_percent": int(background.get("volume_percent", 60)),
+                        },
+                        "ducking": dict(audio_scene.get("ducking") or {}),
+                        "finish": dict(audio_scene.get("finish") or {}),
+                    }
+                    result = await native_satellite.send_command(
+                        selector,
+                        "audio.scene.start",
+                        command_payload,
+                    )
+                    audio_scene_started = True
+                except Exception as exc:
+                    audio_scene_fallback_reason = f"Background audio unavailable; played TTS only: {exc}"
+                    vp.logger.warning(
+                        "[voice_core] audio scene fallback selector=%s error=%s",
+                        selector,
+                        exc,
+                    )
+            elif audio_scene:
+                audio_scene_fallback_reason = "Satellite firmware does not advertise audio scene support."
+
+            media_session_supported = (
+                persistent_media_requested
+                and not audio_scene_started
+                and await native_satellite.client_has_capability(
+                    selector,
+                    "persistent_media_sessions",
+                )
+            )
+            if persistent_media_requested and not audio_scene_started and media_session_supported:
+                command_payload = {
+                    "session_id": playback_id,
+                    "media": {
+                        "url": playback_url,
+                        "volume_percent": media_volume_percent,
+                        "loop": media_loop,
+                        "content_type": media_content_type or "music",
+                    },
+                }
+                result = await native_satellite.send_command(
+                    selector,
+                    "media.session.start",
+                    command_payload,
+                )
+                media_session_started = True
+            elif persistent_media_requested and not audio_scene_started:
+                media_session_fallback_reason = (
+                    "Satellite firmware does not advertise persistent media-session support."
+                )
+
+            overlay_supported = (
+                not persistent_media_requested
+                and not audio_scene_started
+                and not media_session_started
+                and await native_satellite.client_has_capability(selector, "tts_overlays")
+                and await native_satellite.client_media_session_active(selector)
+            )
+            if overlay_supported:
+                command_payload = {
+                    "overlay_id": playback_id,
+                    "foreground": {
+                        "url": playback_url,
+                        "kind": tts_kind or "tts",
+                        "volume_percent": 100,
+                    },
+                    "ducking": dict(ducking),
+                }
+                if continue_conversation:
+                    command_payload["continue_conversation"] = True
+                if conversation_id:
+                    command_payload["conversation_id"] = conversation_id
+                result = await native_satellite.send_command(
+                    selector,
+                    "audio.overlay.start",
+                    command_payload,
+                )
+                audio_overlay_started = True
+
+            if not audio_scene_started and not media_session_started and not audio_overlay_started:
+                command_payload = {"url": playback_url}
+                if tts_kind:
+                    command_payload["tts_kind"] = tts_kind
+                if not persistent_media_requested:
+                    command_payload["ducking"] = dict(ducking)
+                if continue_conversation:
+                    command_payload["continue_conversation"] = True
+                if conversation_id:
+                    command_payload["conversation_id"] = conversation_id
+                result = await native_satellite.send_command(selector, "play.url", command_payload)
         except Exception as exc:
             raise HTTPException(status_code=409, detail=f"Failed to queue native satellite playback: {exc}") from exc
     else:
@@ -838,9 +1129,15 @@ async def native_satellite_play(payload: Dict[str, Any], x_tater_token: Optional
         "source_url": source_url,
         "playback_url": playback_url,
         "media_type": media_type,
+        "media_content_type": media_content_type,
         "playback_mode": "device",
         "reply_playback_target": reply_playback_target,
         "respect_reply_playback": respect_reply_playback,
+        "audio_scene_started": audio_scene_started,
+        "audio_scene_fallback_reason": audio_scene_fallback_reason,
+        "media_session_started": media_session_started,
+        "media_session_fallback_reason": media_session_fallback_reason,
+        "audio_overlay_started": audio_overlay_started,
         **result,
     }
 

--- a/tateros_app.py
+++ b/tateros_app.py
@@ -8793,6 +8793,9 @@ class AppSettingsRequest(BaseModel):
     speech_announcement_tts_backend: Optional[str] = None
     speech_announcement_tts_model: Optional[str] = None
     speech_announcement_tts_voice: Optional[str] = None
+    speech_satellite_ducking_target_percent: Optional[int] = None
+    speech_satellite_ducking_attack_ms: Optional[int] = None
+    speech_satellite_ducking_release_ms: Optional[int] = None
     speech_announcement_wyoming_tts_host: Optional[str] = None
     speech_announcement_wyoming_tts_port: Optional[str] = None
     speech_announcement_wyoming_tts_voice: Optional[str] = None
@@ -17058,6 +17061,21 @@ def get_settings() -> Dict[str, Any]:
         "speech_announcement_tts_backend": str(speech_settings.get("announcement_tts_backend") or ""),
         "speech_announcement_tts_model": str(speech_settings.get("announcement_tts_model") or ""),
         "speech_announcement_tts_voice": str(speech_settings.get("announcement_tts_voice") or ""),
+        "speech_satellite_ducking_target_percent": int(
+            speech_settings.get("satellite_ducking_target_percent")
+            if speech_settings.get("satellite_ducking_target_percent") is not None
+            else 20
+        ),
+        "speech_satellite_ducking_attack_ms": int(
+            speech_settings.get("satellite_ducking_attack_ms")
+            if speech_settings.get("satellite_ducking_attack_ms") is not None
+            else 150
+        ),
+        "speech_satellite_ducking_release_ms": int(
+            speech_settings.get("satellite_ducking_release_ms")
+            if speech_settings.get("satellite_ducking_release_ms") is not None
+            else 350
+        ),
         "speech_announcement_wyoming_tts_host": str(speech_settings.get("announcement_wyoming_tts_host") or ""),
         "speech_announcement_wyoming_tts_port": str(speech_settings.get("announcement_wyoming_tts_port") or ""),
         "speech_announcement_wyoming_tts_voice": str(speech_settings.get("announcement_wyoming_tts_voice") or ""),
@@ -17387,6 +17405,37 @@ async def get_runtime_tts_asset(asset_id: str) -> Response:
 @app.get("/api/speech/tts/runtime/{asset_id}/{filename:path}")
 async def get_runtime_tts_named_asset(asset_id: str, filename: str) -> Response:
     return _runtime_tts_asset_response(asset_id)
+
+
+def _ai_task_background_audio_response(kind: str, filename: str) -> FileResponse:
+    clean_kind = str(kind or "").strip().lower()
+    clean_filename = Path(str(filename or "").strip()).name
+    if (
+        clean_kind not in {"presets", "uploads"}
+        or not clean_filename
+        or clean_filename != str(filename or "").strip()
+        or Path(clean_filename).suffix.lower() not in {".wav", ".mp3", ".flac"}
+    ):
+        raise HTTPException(status_code=404, detail="Background audio not found.")
+
+    root = agent_lab_path("ai_task", "background_audio", clean_kind).resolve()
+    candidate = (root / clean_filename).resolve()
+    if root not in candidate.parents or not candidate.is_file():
+        raise HTTPException(status_code=404, detail="Background audio not found.")
+
+    media_type = str(mimetypes.guess_type(clean_filename)[0] or "").strip()
+    if not media_type:
+        media_type = {
+            ".wav": "audio/wav",
+            ".mp3": "audio/mpeg",
+            ".flac": "audio/flac",
+        }.get(candidate.suffix.lower(), "application/octet-stream")
+    return FileResponse(candidate, media_type=media_type, filename=clean_filename)
+
+
+@app.get("/api/ai-tasks/background-audio/{kind}/{filename}")
+async def get_ai_task_background_audio(kind: str, filename: str) -> FileResponse:
+    return _ai_task_background_audio_response(kind, filename)
 
 
 @app.post("/api/settings/speech/wyoming-tts-voices")
@@ -18736,6 +18785,9 @@ def update_settings(payload: AppSettingsRequest, response: Response) -> Dict[str
         "speech_announcement_tts_backend",
         "speech_announcement_tts_model",
         "speech_announcement_tts_voice",
+        "speech_satellite_ducking_target_percent",
+        "speech_satellite_ducking_attack_ms",
+        "speech_satellite_ducking_release_ms",
         "speech_announcement_wyoming_tts_host",
         "speech_announcement_wyoming_tts_port",
         "speech_announcement_wyoming_tts_voice",
@@ -18764,6 +18816,9 @@ def update_settings(payload: AppSettingsRequest, response: Response) -> Dict[str
         "speech_kokoro_output_gain",
         "speech_pocket_tts_output_gain",
         "speech_chatterbox_tts_streaming_enabled",
+        "speech_satellite_ducking_target_percent",
+        "speech_satellite_ducking_attack_ms",
+        "speech_satellite_ducking_release_ms",
     }
     if any(key in updates for key in speech_keys):
         current_speech = get_shared_speech_settings()
@@ -18844,6 +18899,18 @@ def update_settings(payload: AppSettingsRequest, response: Response) -> Dict[str
             announcement_tts_voice=str(
                 updates.get("speech_announcement_tts_voice", current_speech.get("announcement_tts_voice") or "")
             ).strip(),
+            satellite_ducking_target_percent=updates.get(
+                "speech_satellite_ducking_target_percent",
+                current_speech.get("satellite_ducking_target_percent"),
+            ),
+            satellite_ducking_attack_ms=updates.get(
+                "speech_satellite_ducking_attack_ms",
+                current_speech.get("satellite_ducking_attack_ms"),
+            ),
+            satellite_ducking_release_ms=updates.get(
+                "speech_satellite_ducking_release_ms",
+                current_speech.get("satellite_ducking_release_ms"),
+            ),
             announcement_wyoming_tts_host=str(
                 updates.get(
                     "speech_announcement_wyoming_tts_host",

--- a/tateros_static/app.js
+++ b/tateros_static/app.js
@@ -4463,8 +4463,11 @@ function buildSettingInput(field, inputId) {
   const safeDesc = field.description ? `<div class="small">${escapeHtml(field.description)}</div>` : "";
   const type = String(field.type || "text").toLowerCase();
   const showWhen = field?.show_when && typeof field.show_when === "object" ? field.show_when : {};
-  const wrapRuntimeSetting = (html) => {
-    const sourceKey = String(showWhen?.source_key ?? showWhen?.key ?? "").trim();
+  const showWhenAll = Array.isArray(field?.show_when_all)
+    ? field.show_when_all.filter((item) => item && typeof item === "object")
+    : [];
+  const wrapRuntimeSettingCondition = (html, condition) => {
+    const sourceKey = String(condition?.source_key ?? condition?.key ?? "").trim();
     const values = [];
     const addValue = (raw) => {
       const token = String(raw ?? "").trim();
@@ -4472,17 +4475,17 @@ function buildSettingInput(field, inputId) {
         values.push(token);
       }
     };
-    if (Array.isArray(showWhen?.any_of)) {
-      showWhen.any_of.forEach(addValue);
+    if (Array.isArray(condition?.any_of)) {
+      condition.any_of.forEach(addValue);
     }
-    if (Array.isArray(showWhen?.values)) {
-      showWhen.values.forEach(addValue);
+    if (Array.isArray(condition?.values)) {
+      condition.values.forEach(addValue);
     }
-    if (showWhen?.equals !== undefined) {
-      addValue(showWhen.equals);
+    if (condition?.equals !== undefined) {
+      addValue(condition.equals);
     }
-    if (showWhen?.value !== undefined) {
-      addValue(showWhen.value);
+    if (condition?.value !== undefined) {
+      addValue(condition.value);
     }
     if (!sourceKey || !values.length) {
       return html;
@@ -4497,6 +4500,19 @@ function buildSettingInput(field, inputId) {
       encoded
     )}">${html}</div>`;
   };
+  const wrapRuntimeSetting = (html) =>
+    showWhenAll.length
+      ? showWhenAll.reduce(
+          (currentHtml, condition) => wrapRuntimeSettingCondition(currentHtml, condition),
+          html
+        )
+      : wrapRuntimeSettingCondition(html, showWhen);
+
+  if (type === "hidden") {
+    return `<input id="${inputId}" type="hidden" value="${escapeHtml(
+      field.value ?? ""
+    )}" data-setting-type="hidden" data-setting-key="${safeKey}" />`;
+  }
 
   if (type === "section" || type === "header") {
     return wrapRuntimeSetting(`
@@ -4597,11 +4613,21 @@ function buildSettingInput(field, inputId) {
   if (type === "file") {
     const accept = String(field.accept || "").trim();
     const acceptAttr = accept ? ` accept="${escapeHtml(accept)}"` : "";
+    const fileEncoding = String(field.file_encoding || field.encoding || "").trim().toLowerCase();
+    const fileEncodingAttr = fileEncoding
+      ? ` data-setting-file-encoding="${escapeHtml(fileEncoding)}"`
+      : "";
+    const maxBytes = Number(field.max_bytes || 0);
+    const maxBytesAttr = Number.isFinite(maxBytes) && maxBytes > 0
+      ? ` data-setting-max-bytes="${Math.floor(maxBytes)}"`
+      : "";
     const currentValue = String(field.value ?? "");
-    const currentSummary = currentValue
-      ? `Current file content saved (${currentValue.length.toLocaleString()} characters).`
-      : "No file saved.";
-    return wrapRuntimeSetting(`<label>${safeLabel}<input id="${inputId}" type="file"${acceptAttr} data-setting-type="file" data-setting-key="${safeKey}" /><textarea hidden data-setting-current-key="${safeKey}">${escapeHtml(
+    const currentSummary = fileEncoding === "base64"
+      ? "Choose a file to upload. Leave it empty to keep the currently selected audio."
+      : currentValue
+        ? `Current file content saved (${currentValue.length.toLocaleString()} characters).`
+        : "No file saved.";
+    return wrapRuntimeSetting(`<label>${safeLabel}<input id="${inputId}" type="file"${acceptAttr}${fileEncodingAttr}${maxBytesAttr} data-setting-type="file" data-setting-key="${safeKey}" /><textarea hidden data-setting-current-key="${safeKey}">${escapeHtml(
       currentValue
     )}</textarea><div class="small">${escapeHtml(currentSummary)}</div>${safeDesc}</label>`);
   }
@@ -4635,6 +4661,32 @@ function buildSettingInput(field, inputId) {
   return wrapRuntimeSetting(`<label>${safeLabel}${inputHtml}${safeDesc}</label>`);
 }
 
+async function readFileAsBase64Payload(file, maxBytes = 0) {
+  if (!(file instanceof File)) {
+    return null;
+  }
+  const limit = Number(maxBytes || 0);
+  if (Number.isFinite(limit) && limit > 0 && file.size > limit) {
+    throw new Error(`${file.name || "Selected file"} is larger than ${Math.floor(limit / (1024 * 1024))} MB.`);
+  }
+  const dataUrl = await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => resolve(String(reader.result || "")));
+    reader.addEventListener("error", () => reject(reader.error || new Error("Could not read the selected file.")));
+    reader.readAsDataURL(file);
+  });
+  const commaIndex = dataUrl.indexOf(",");
+  if (commaIndex < 0) {
+    throw new Error(`${file.name || "Selected file"} could not be encoded.`);
+  }
+  return {
+    filename: String(file.name || "upload.bin"),
+    content_type: String(file.type || "application/octet-stream"),
+    size: Number(file.size || 0),
+    data_b64: dataUrl.slice(commaIndex + 1),
+  };
+}
+
 async function getInputValue(input) {
   const type = input.dataset.settingType || input.type;
   if (type === "multiselect") {
@@ -4653,6 +4705,9 @@ async function getInputValue(input) {
         (item) => String(item?.dataset?.settingCurrentKey || "").trim() === key
       );
       return current ? current.value : "";
+    }
+    if (String(input.dataset.settingFileEncoding || "").trim().toLowerCase() === "base64") {
+      return readFileAsBase64Payload(file, Number(input.dataset.settingMaxBytes || 0));
     }
     const text = await file.text();
     const accept = String(input.getAttribute("accept") || "").toLowerCase();
@@ -7559,6 +7614,26 @@ function renderCoreManagerField(field) {
     )}" data-core-field-type="hidden" />`;
   }
 
+  if (type === "file") {
+    const accept = String(field?.accept || "").trim();
+    const acceptAttr = accept ? ` accept="${escapeHtml(accept)}"` : "";
+    const fileEncoding = String(field?.file_encoding || field?.encoding || "").trim().toLowerCase();
+    const fileEncodingAttr = fileEncoding
+      ? ` data-core-file-encoding="${escapeHtml(fileEncoding)}"`
+      : "";
+    const maxBytes = Number(field?.max_bytes || 0);
+    const maxBytesAttr = Number.isFinite(maxBytes) && maxBytes > 0
+      ? ` data-core-file-max-bytes="${Math.floor(maxBytes)}"`
+      : "";
+    return wrapField(`
+      <label>${escapeHtml(label)}
+        <input type="file"${acceptAttr}${fileEncodingAttr}${maxBytesAttr}${disabledAttr}
+          data-core-field-key="${escapeHtml(key)}" data-core-field-type="file" />
+        ${descHtml}
+      </label>
+    `);
+  }
+
   if (type === "table") {
     const rawColumns = Array.isArray(field?.columns) ? field.columns : [];
     const columns = rawColumns
@@ -9147,15 +9222,18 @@ function renderEspHomeSensorRows(sensorRows, sensorTitle = "Live Entities", conn
 
 function renderEspHomeSatelliteCard(item, coreKey = "voice", displaySensors = null) {
   const itemId = String(item?.id || "").trim();
+  const itemGroup = String(item?.group || "satellite").trim() || "satellite";
   const encodedId = escapeHtml(encodeCoreManagerId(itemId));
   const title = String(item?.title || itemId || "Satellite").trim() || "Satellite";
   const subtitle = String(item?.subtitle || "").trim();
   const detail = String(item?.detail || "").trim();
   const saveAction = String(item?.save_action || "").trim();
+  const saveLabel = String(item?.save_label || "Save").trim() || "Save";
   const settingsSaveAction = String(item?.settings_save_action || saveAction || "").trim();
   const identifyAction = String(item?.identify_action || "").trim();
   const identifyLabel = String(item?.identify_label || "Identify").trim() || "Identify";
   const removeAction = String(item?.remove_action || "").trim();
+  const removeLabel = String(item?.remove_label || "Forget").trim() || "Forget";
   const runAction = String(item?.run_action || "").trim();
   const runConfirm = String(item?.run_confirm || "").trim();
   const removeConfirm = String(item?.remove_confirm || "Forget this satellite?").trim();
@@ -9226,7 +9304,7 @@ function renderEspHomeSatelliteCard(item, coreKey = "voice", displaySensors = nu
     <article class="card core-manager-item esphome-satellite-card"
       data-core-key="${escapeHtml(coreKey)}"
       data-core-item-id="${encodedId}"
-      data-core-item-group="satellite"
+      data-core-item-group="${escapeHtml(itemGroup)}"
       data-core-save-action="${escapeHtml(saveAction)}"
       data-core-settings-action="${escapeHtml(settingsSaveAction)}"
       data-core-identify-action="${escapeHtml(identifyAction)}"
@@ -9251,7 +9329,7 @@ function renderEspHomeSatelliteCard(item, coreKey = "voice", displaySensors = nu
       ${summaryBlockHtml}
       ${fields.length ? `<div class="form-grid">${fields.map((field) => renderCoreManagerField(field)).join("")}</div>` : ""}
       <div class="inline-row" style="margin-top:10px;">
-        ${saveAction ? `<button type="button" class="action-btn core-manager-save">Save</button>` : ""}
+        ${saveAction ? `<button type="button" class="action-btn core-manager-save">${escapeHtml(saveLabel)}</button>` : ""}
         ${
           identifyAction
             ? `<button type="button" class="inline-btn esphome-satellite-identify" ${
@@ -9262,7 +9340,7 @@ function renderEspHomeSatelliteCard(item, coreKey = "voice", displaySensors = nu
         ${showEntityRefresh ? `<button type="button" class="inline-btn esphome-entities-refresh">Refresh Entities</button>` : ""}
         ${infoFields.length ? `<button type="button" class="inline-btn core-manager-info">${escapeHtml(infoLabel)}</button>` : ""}
         ${popupFields.length ? `<button type="button" class="action-btn core-manager-settings">${escapeHtml(settingsLabel)}</button>` : ""}
-        ${removeAction ? `<button type="button" class="inline-btn danger core-manager-remove">Forget</button>` : ""}
+        ${removeAction ? `<button type="button" class="inline-btn danger core-manager-remove">${escapeHtml(removeLabel)}</button>` : ""}
         ${runAction ? `<button type="button" class="action-btn core-manager-run" style="margin-left:auto;">${escapeHtml(String(item?.run_label || "Run"))}</button>` : ""}
         <span class="small core-manager-status"></span>
       </div>
@@ -10832,6 +10910,13 @@ function _coreFieldByKey(host, key) {
   return candidates.find((node) => String(node?.dataset?.coreFieldKey || "").trim() === wanted) || null;
 }
 
+function _coreConditionInputValue(input) {
+  if (input instanceof HTMLInputElement && input.type === "checkbox") {
+    return input.checked ? "true" : "false";
+  }
+  return String(input?.value || "").trim();
+}
+
 function _coreDecodeDependentJson(raw, fallback) {
   const token = String(raw || "").trim();
   if (!token) {
@@ -11037,7 +11122,7 @@ function bindCoreManagerConditionalFields() {
       return;
     }
     const refresh = () => {
-      const sourceValue = String(sourceInput.value || "").trim();
+      const sourceValue = _coreConditionInputValue(sourceInput);
       const visible = allowedValues.includes(sourceValue);
       container.style.display = visible ? "" : "none";
       container.setAttribute("aria-hidden", visible ? "false" : "true");
@@ -11082,7 +11167,7 @@ function bindCoreManagerConditionalDisabledFields() {
       return;
     }
     const refresh = () => {
-      const sourceValue = String(sourceInput.value || "").trim();
+      const sourceValue = _coreConditionInputValue(sourceInput);
       const muted = mutedValues.includes(sourceValue);
       container.classList.toggle("core-conditionally-muted", muted);
       container.setAttribute("aria-disabled", muted ? "true" : "false");
@@ -11137,7 +11222,7 @@ function bindCoreManagerDependentSelects() {
     const isMulti = targetSelect.multiple || String(targetSelect.dataset.coreFieldType || "").toLowerCase() === "multiselect";
 
     const refresh = () => {
-      const sourceValue = String(sourceInput.value || "").trim();
+      const sourceValue = _coreConditionInputValue(sourceInput);
       const sourceRows = optionsBySource && typeof optionsBySource === "object" ? optionsBySource[sourceValue] : [];
       const narrowed = _coreNormalizeOptionRows(sourceRows);
       let nextRows = defaultOptions;
@@ -11183,6 +11268,9 @@ function collectCoreManagerValues(host) {
       return;
     }
     const type = String(input.dataset.coreFieldType || input.type || "").toLowerCase();
+    if (type === "file") {
+      return;
+    }
     if (type === "checkbox") {
       values[key] = Boolean(input.checked);
       return;
@@ -11200,6 +11288,33 @@ function collectCoreManagerValues(host) {
     }
     values[key] = input.value;
   });
+  return values;
+}
+
+async function collectCoreManagerValuesWithFiles(host) {
+  const values = collectCoreManagerValues(host);
+  for (const input of host.querySelectorAll("[data-core-field-key][data-core-field-type='file']")) {
+    if (input.disabled || !(input instanceof HTMLInputElement)) {
+      continue;
+    }
+    const file = input.files && input.files.length ? input.files[0] : null;
+    if (!file) {
+      continue;
+    }
+    const key = String(input.dataset.coreFieldKey || "").trim();
+    if (!key) {
+      continue;
+    }
+    const encoding = String(input.dataset.coreFileEncoding || "").trim().toLowerCase();
+    if (encoding !== "base64") {
+      values[key] = String(await file.text());
+      continue;
+    }
+    values[key] = await readFileAsBase64Payload(
+      file,
+      Number(input.dataset.coreFileMaxBytes || 0)
+    );
+  }
   return values;
 }
 
@@ -11355,6 +11470,9 @@ async function ensureEspHomeRuntimeLoaded({ force = false, panel = "" } = {}) {
       const wakeVerifierItem =
         itemForms.find((item) => String(item?.group || "").trim().toLowerCase() === "wake_verifier") || null;
       const satelliteItems = itemForms.filter((item) => String(item?.group || "").trim().toLowerCase() === "satellite");
+      const stereoPairItems = itemForms.filter((item) =>
+        ["stereo_pair", "stereo_pair_create"].includes(String(item?.group || "").trim().toLowerCase())
+      );
       const addForm = ui?.add_form && typeof ui.add_form === "object" ? ui.add_form : {};
       const nativePairing = ui?.native_pairing && typeof ui.native_pairing === "object" ? ui.native_pairing : {};
       const summary = String(body.summary || "").trim();
@@ -11385,11 +11503,25 @@ async function ensureEspHomeRuntimeLoaded({ force = false, panel = "" } = {}) {
         ? renderEspHomeSettingsCard(wakeVerifierItem, coreKey)
         : renderNotice("Wake verification settings are unavailable.");
       if (targetPanel === "satellites") {
-        satellitesHost.innerHTML = satelliteItems.length
+        const stereoPairHtml = stereoPairItems.length
+          ? `
+            <section class="core-inline-section" style="margin-bottom:16px;">
+              <div class="small core-inline-section-title">Stereo Pairs</div>
+              <div class="small">Paired satellites appear as one synchronized destination across Tater.</div>
+              <div class="core-tab-items core-tab-items-group-stereo-pair" style="margin-top:10px;">
+                ${stereoPairItems
+                  .map((item) => renderEspHomeSatelliteCard(item, coreKey, displaySensors))
+                  .join("")}
+              </div>
+            </section>
+          `
+          : "";
+        const satelliteHtml = satelliteItems.length
           ? `<div class="core-tab-items core-tab-items-group-satellite">${satelliteItems
               .map((item) => renderEspHomeSatelliteCard(item, coreKey, displaySensors))
               .join("")}</div>`
           : renderNotice(emptyMessage);
+        satellitesHost.innerHTML = `${stereoPairHtml}${satelliteHtml}`;
         addHost.innerHTML =
           nativePairing?.start_action && nativePairing?.status_action
             ? renderNativeSatellitePairingPanel(nativePairing, coreKey)
@@ -15128,9 +15260,9 @@ function bindCoreTabManagers() {
       if (!coreKey || !action) {
         return;
       }
-      const values = collectCoreManagerValues(form);
       setCoreManagerStatus(form, "Saving...");
       try {
+        const values = await collectCoreManagerValuesWithFiles(form);
         const activeTab = persistCoreTabFromNode(form);
         const result = await runActionWithProgress(
           {
@@ -15275,9 +15407,9 @@ function bindCoreTabManagers() {
       if (!card || !coreKey || !action) {
         return;
       }
-      const values = collectCoreManagerValues(card);
       setCoreManagerStatus(card, "Saving...");
       try {
+        const values = await collectCoreManagerValuesWithFiles(card);
         const activeTab = persistCoreTabFromNode(card);
         const result = await runActionWithProgress(
           {
@@ -21260,6 +21392,25 @@ async function loadSettingsView() {
                 <div class="small hydra-model-panel-note" style="grid-column: 1 / -1;">
                   Default for Voice Core announcement flows used by cores and verbas.
                 </div>
+                <div class="small core-inline-section-title" style="grid-column: 1 / -1;">Satellite Media Ducking</div>
+                <div class="small hydra-model-panel-note" style="grid-column: 1 / -1;">
+                  Applied when ordinary TTS plays over an active native-satellite media session. Individual audio scenes can override these values.
+                </div>
+                <label>Ducked Media Level (%)
+                  <input id="set_speech_satellite_ducking_target_percent" type="number" min="0" max="100" value="${escapeHtml(
+                    settings.speech_satellite_ducking_target_percent ?? 20
+                  )}" />
+                </label>
+                <label>Duck Attack (ms)
+                  <input id="set_speech_satellite_ducking_attack_ms" type="number" min="0" max="10000" value="${escapeHtml(
+                    settings.speech_satellite_ducking_attack_ms ?? 150
+                  )}" />
+                </label>
+                <label>Volume Restore (ms)
+                  <input id="set_speech_satellite_ducking_release_ms" type="number" min="0" max="10000" value="${escapeHtml(
+                    settings.speech_satellite_ducking_release_ms ?? 350
+                  )}" />
+                </label>
                 <label>Announcement Backend
                   <select id="set_speech_announcement_tts_backend">
                     ${renderSettingsSelectOptions(announcementTtsBackendOptions, currentAnnouncementTtsBackend)}
@@ -26320,6 +26471,15 @@ async function loadSettingsView() {
     speech_announcement_tts_backend: String(document.getElementById("set_speech_announcement_tts_backend")?.value || "").trim(),
     speech_announcement_tts_model: getAnnouncementTtsModelValue(),
     speech_announcement_tts_voice: getAnnouncementTtsVoiceValue(),
+    speech_satellite_ducking_target_percent: readOptionalNumberValue(
+      document.getElementById("set_speech_satellite_ducking_target_percent")
+    ),
+    speech_satellite_ducking_attack_ms: readOptionalNumberValue(
+      document.getElementById("set_speech_satellite_ducking_attack_ms")
+    ),
+    speech_satellite_ducking_release_ms: readOptionalNumberValue(
+      document.getElementById("set_speech_satellite_ducking_release_ms")
+    ),
     speech_announcement_wyoming_tts_host: String(announcementWyomingTtsHostEl?.value || "").trim(),
     speech_announcement_wyoming_tts_port: String(announcementWyomingTtsPortEl?.value || "").trim(),
     speech_announcement_wyoming_tts_voice: String(announcementWyomingTtsVoiceEl?.value || "").trim(),


### PR DESCRIPTION
## What changed

- Add first-class AI Task broadcast destinations and secure Agent Lab background-audio asset serving for AI Task Core 1.2.0 and Broadcast Verba 1.3.0.
- Add persistent native media sessions, configurable TTS ducking, synchronized background-audio scenes, and compatibility fallbacks.
- Add configurable native stereo pairs with left/right routing, synchronized starts, centered TTS, per-side level/delay calibration, playhead telemetry, and bounded drift correction.
- Make stereo pairs available throughout Tater as one announcement/media destination, including AI Task, Broadcast, Audio ACE, and Reply Playback.
- Normalize `VOICE_CORE_PUBLIC_BASE_URL` consistently for native TTS, streaming TTS, music, and background assets.
- Update the macOS bundle and release notes to Tater v98, build 126.

## Related releases

- Tater Native Firmware `native-0.3.0`
- AI Task Scheduler Core `1.2.0`
- Broadcast Verba `1.3.0`

## Validation

- 156 repository script tests passed
- 7 native timer tests passed
- 25 focused audio/stereo/release tests passed
- Python compilation checks passed
- JavaScript syntax check passed
- macOS plist validation and v98 tag/version validation passed
- `git diff --check` passed
